### PR TITLE
Add reference to dua-cli in the README as similar tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ sudo pacman -S parallel-disk-usage
   * `du`
   * [`dust`](https://github.com/bootandy/dust)
   * [`dutree`](https://github.com/nachoparker/dutree)
+  * [`dua`](https://github.com/byron/dua-cli)
 * **TUI:**
   * [`ncdu`](https://dev.yorhel.nl/ncdu)
   * [`gdu`](https://github.com/dundee/gdu)
   * [`godu`](https://github.com/viktomas/godu)
+  * [`dua`](https://github.com/byron/dua-cli)
 * **GUI:**
   * [GNOME's Disk Usage Analyzer, a.k.a. `baobab`](https://wiki.gnome.org/action/show/Apps/DiskUsageAnalyzer)
   * Filelight

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ sudo pacman -S parallel-disk-usage
   * [`ncdu`](https://dev.yorhel.nl/ncdu)
   * [`gdu`](https://github.com/dundee/gdu)
   * [`godu`](https://github.com/viktomas/godu)
-  * [`dua`](https://github.com/byron/dua-cli)
 * **GUI:**
   * [GNOME's Disk Usage Analyzer, a.k.a. `baobab`](https://wiki.gnome.org/action/show/Apps/DiskUsageAnalyzer)
   * Filelight


### PR DESCRIPTION
As `dua` is providing both a CLI mode as well as an interactive mode via `dua i` I placed it into both categories.

Disclaimer: I am the author of this tool and have adapted [this paragraph](https://github.com/Byron/dua-cli/blob/60f432417fe2adbbd54de7293f1c3ffcd45365f7/README.md#L168-L181) for my own README.

Edit: Now that I got to use `pdu` a little I finally get to appreciate the way the data is presented. Whereas `dua` gives a high-level overview and `pdu` dives in to reveal exactly where the main offenders in terms of disk space usage are. It took me a while and I even wrote my own tool to solve this problem, but finally I can see the benefits of this kind of visualization.

`dust` never worked for me as it was too slow and…used too much memory, so `pdu` truly makes a difference here.

Lastly I encourage you to build a TUI which allows the safe deletion of picked items to support the entire workflow people are usually using `pdu` for.