### PR TITLE
docs(readme): add archlinuxcn repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ Follow the [installation instruction](https://github.com/KSXGitHub/pacman-repo#i
 sudo pacman -S parallel-disk-usage
 ```
 
+#### From [Arch Linux CN Repository](https://github.com/archlinuxcn/repo)
+
+Follow the [installation instruction](https://github.com/archlinuxcn/repo#usage) then run the following command:
+
+```sh
+sudo pacman -S parallel-disk-usage
+```
+
 ## Distributions
 
 [![Packaging Status](https://repology.org/badge/vertical-allrepos/parallel-disk-usage.svg)](https://repology.org/project/parallel-disk-usage/versions)


### PR DESCRIPTION
`parallel-disk-usage` has been packaged in `archlinuxcn` repository, which is a third-party repository of Arch Linux.

Package Link: https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/parallel-disk-usage