### PR TITLE
perf!: move depth computation from visualizer to tree builder

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -57,7 +57,6 @@ impl App {
                 bytes_format,
                 top_down,
                 align_right,
-                max_depth,
                 ..
             } = self.args;
             let direction = Direction::from_top_down(top_down);
@@ -79,7 +78,6 @@ impl App {
                         column_width_distribution,
                         direction,
                         bar_alignment,
-                        max_depth,
                     }
                     .to_string()
                 }};

--- a/src/app/sub.rs
+++ b/src/app/sub.rs
@@ -144,7 +144,6 @@ where
             direction,
             bar_alignment,
             column_width_distribution,
-            max_depth,
         };
 
         print!("{visualizer}"); // visualizer already ends with "\n", println! isn't needed here.

--- a/src/app/sub.rs
+++ b/src/app/sub.rs
@@ -76,6 +76,7 @@ where
                     reporter: &reporter,
                     root,
                     size_getter,
+                    max_depth: max_depth.get() as u64,
                 }
                 .into()
             });
@@ -100,6 +101,7 @@ where
                 OsStringDisplay::os_string_from("(total)"),
                 Size::default(),
                 children,
+                max_depth.get() as u64,
             )
         };
 

--- a/src/app/sub.rs
+++ b/src/app/sub.rs
@@ -12,7 +12,7 @@ use crate::{
     visualizer::{BarAlignment, ColumnWidthDistribution, Direction, Visualizer},
 };
 use serde::Serialize;
-use std::{io::stdout, iter::once, num::NonZeroUsize, path::PathBuf};
+use std::{io::stdout, iter::once, num::NonZeroU64, path::PathBuf};
 
 /// The sub program of the main application.
 pub struct Sub<Size, SizeGetter, Report>
@@ -35,7 +35,7 @@ where
     /// Distribution and number of characters/blocks can be placed in a line.
     pub column_width_distribution: ColumnWidthDistribution,
     /// Maximum number of levels that should be visualized.
-    pub max_depth: NonZeroUsize,
+    pub max_depth: NonZeroU64,
     /// [Get the size](GetSize) of files/directories.
     pub size_getter: SizeGetter,
     /// Reports measurement progress.
@@ -76,7 +76,7 @@ where
                     reporter: &reporter,
                     root,
                     size_getter,
-                    max_depth: max_depth.get() as u64,
+                    max_depth: max_depth.get(),
                 }
                 .into()
             });
@@ -101,7 +101,7 @@ where
                 OsStringDisplay::os_string_from("(total)"),
                 Size::default(),
                 children,
-                max_depth.get() as u64,
+                max_depth.get(),
             )
         };
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ pub use threads::Threads;
 
 use crate::{bytes_format::BytesFormat, visualizer::ColumnWidthDistribution};
 use clap::{ColorChoice, Parser};
-use std::{num::NonZeroUsize, path::PathBuf};
+use std::{num::NonZeroU64, path::PathBuf};
 use terminal_size::{terminal_size, Width};
 use text_block_macros::text_block;
 
@@ -105,7 +105,7 @@ pub struct Args {
 
     /// Maximum depth to display the data (must be greater than 0).
     #[clap(long, default_value = "10")]
-    pub max_depth: NonZeroUsize,
+    pub max_depth: NonZeroU64,
 
     /// Width of the visualization.
     #[clap(long, conflicts_with = "column_width")]

--- a/src/data_tree.rs
+++ b/src/data_tree.rs
@@ -25,7 +25,7 @@ use super::size;
 pub struct DataTree<Name, Size: size::Size> {
     name: Name,
     size: Size,
-    children: Vec<Self>, // TODO: turn this into a semi zero-sized type
+    children: Vec<Self>,
 }
 
 mod constructors;

--- a/src/data_tree.rs
+++ b/src/data_tree.rs
@@ -25,7 +25,7 @@ use super::size;
 pub struct DataTree<Name, Size: size::Size> {
     name: Name,
     size: Size,
-    children: Vec<Self>,
+    children: Vec<Self>, // TODO: turn this into a semi zero-sized type
 }
 
 mod constructors;

--- a/src/data_tree/constructors.rs
+++ b/src/data_tree/constructors.rs
@@ -3,8 +3,9 @@ use crate::size;
 
 impl<Name, Size: size::Size> DataTree<Name, Size> {
     /// Create a tree representation of a directory.
-    pub fn dir(name: Name, inode_size: Size, children: Vec<Self>) -> Self {
+    pub fn dir(name: Name, inode_size: Size, children: Vec<Self>, depth: u64) -> Self {
         let size = inode_size + children.iter().map(DataTree::size).sum();
+        let children = if depth > 0 { children } else { Vec::new() };
         DataTree {
             name,
             size,
@@ -26,6 +27,6 @@ impl<Name, Size: size::Size> DataTree<Name, Size> {
     where
         Size: Copy,
     {
-        move |name, children| DataTree::dir(name, inode_size, children)
+        move |name, children| DataTree::dir(name, inode_size, children, 1)
     }
 }

--- a/src/data_tree/retain.rs
+++ b/src/data_tree/retain.rs
@@ -7,16 +7,30 @@ where
     Self: Send,
     Size: size::Size,
 {
-    /// Recursively cull all descendants that do not satisfy given `predicate`, in parallel.
-    pub fn par_retain(&mut self, predicate: impl Fn(&Self) -> bool + Copy + Sync) {
-        self.children.retain(predicate);
+    /// Internal function to be used by [`Self::par_retain`].
+    fn par_retain_with_depth(
+        &mut self,
+        current_depth: u64,
+        predicate: impl Fn(&Self, u64) -> bool + Copy + Sync,
+    ) {
+        self.children
+            .retain(|child| predicate(child, current_depth));
+        let next_depth = current_depth + 1;
         self.children
             .par_iter_mut()
-            .for_each(|child| child.par_retain(predicate));
+            .for_each(|child| child.par_retain_with_depth(next_depth, predicate))
+    }
+
+    /// Recursively cull all descendants that do not satisfy given `predicate`, in parallel.
+    pub fn par_retain(&mut self, predicate: impl Fn(&Self, u64) -> bool + Copy + Sync) {
+        self.par_retain_with_depth(0, predicate)
     }
 
     /// Process the tree via [`par_retain`](Self::par_retain) method.
-    pub fn into_par_retained(mut self, predicate: impl Fn(&Self) -> bool + Copy + Sync) -> Self {
+    pub fn into_par_retained(
+        mut self,
+        predicate: impl Fn(&Self, u64) -> bool + Copy + Sync,
+    ) -> Self {
         self.par_retain(predicate);
         self
     }
@@ -28,7 +42,7 @@ where
         Size: Into<u64>,
     {
         let minimal = self.size().into() as f32 * min_ratio;
-        self.par_retain(|descendant| descendant.size().into() as f32 >= minimal);
+        self.par_retain(|descendant, _| descendant.size().into() as f32 >= minimal);
     }
 
     /// Process the tree via [`par_cull_insignificant_data`](Self::par_cull_insignificant_data) method.

--- a/src/data_tree/retain/test.rs
+++ b/src/data_tree/retain/test.rs
@@ -7,7 +7,7 @@ type SampleData = Bytes;
 type SampleTree = DataTree<SampleName, SampleData>;
 
 fn dir<const INODE_SIZE: u64>(name: &'static str, children: Vec<SampleTree>) -> SampleTree {
-    SampleTree::dir(name.to_string(), INODE_SIZE.into(), children)
+    SampleTree::dir(name.to_string(), INODE_SIZE.into(), children, 10)
 }
 
 fn file(name: &'static str, size: u64) -> SampleTree {
@@ -23,6 +23,7 @@ fn culled_dir<const INODE_SIZE: u64>(
         name.to_string(),
         (INODE_SIZE + culled_size).into(),
         children,
+        10,
     )
 }
 

--- a/src/data_tree/retain/test.rs
+++ b/src/data_tree/retain/test.rs
@@ -157,7 +157,7 @@ fn edge_cases() {
             ),
         ],
     )
-    .into_par_retained(|descendant| descendant.name().starts_with('!').not())
+    .into_par_retained(|descendant, _| descendant.name().starts_with('!').not())
     .into_reflection();
     let expected = dir(
         "root",

--- a/src/fs_tree_builder.rs
+++ b/src/fs_tree_builder.rs
@@ -29,6 +29,7 @@ use std::{
 ///     root: std::env::current_dir().unwrap(),
 ///     size_getter: GetApparentSize,
 ///     reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+///     max_depth: 10,
 /// };
 /// let data_tree: DataTree<OsStringDisplay, Bytes> = builder.into();
 /// ```
@@ -45,6 +46,8 @@ where
     pub size_getter: SizeGetter,
     /// Reports progress to external system.
     pub reporter: Report,
+    /// Deepest level of descendent display in the graph. The size still counts toward total beyond the depth.
+    pub max_depth: u64,
 }
 
 impl<Size, SizeGetter, Report> From<FsTreeBuilder<Size, SizeGetter, Report>>
@@ -60,6 +63,7 @@ where
             root,
             size_getter,
             reporter,
+            max_depth,
         } = builder;
 
         TreeBuilder::<PathBuf, OsStringDisplay, Size, _, _> {
@@ -118,6 +122,8 @@ where
             },
 
             join_path: |prefix, name| prefix.join(&name.0),
+
+            max_depth,
         }
         .into()
     }

--- a/src/fs_tree_builder.rs
+++ b/src/fs_tree_builder.rs
@@ -46,7 +46,7 @@ where
     pub size_getter: SizeGetter,
     /// Reports progress to external system.
     pub reporter: Report,
-    /// Deepest level of descendent display in the graph. The size still counts toward total beyond the depth.
+    /// Deepest level of descendent display in the graph. The sizes beyond the max depth still count toward total.
     pub max_depth: u64,
 }
 

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -23,7 +23,7 @@ where
     pub get_info: GetInfo,
     /// Function to join parent's `path` with a child's name to make the child's `name`.
     pub join_path: JoinPath,
-    /// Deepest level of descendent to store as arrays. The size still counts toward total beyond the depth.
+    /// Deepest level of descendent to store as arrays. The sizes beyond the max depth still count toward total.
     pub max_depth: u64,
 }
 

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -23,6 +23,8 @@ where
     pub get_info: GetInfo,
     /// Function to join parent's `path` with a child's name to make the child's `name`.
     pub join_path: JoinPath,
+    /// Deepest level of descendent to store as arrays. The size still counts toward total beyond the depth.
+    pub max_depth: u64,
 }
 
 impl<Path, Name, Size, GetInfo, JoinPath> From<TreeBuilder<Path, Name, Size, GetInfo, JoinPath>>
@@ -41,9 +43,11 @@ where
             name,
             get_info,
             join_path,
+            max_depth: current_depth,
         } = builder;
 
         let Info { size, children } = get_info(&path);
+        let next_depth = current_depth.saturating_sub(1);
 
         let children: Vec<_> = children
             .into_par_iter()
@@ -52,10 +56,11 @@ where
                 name,
                 get_info,
                 join_path,
+                max_depth: next_depth,
             })
             .map(Self::from)
             .collect();
 
-        DataTree::dir(name, size, children)
+        DataTree::dir(name, size, children, current_depth)
     }
 }

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -43,11 +43,11 @@ where
             name,
             get_info,
             join_path,
-            max_depth: current_depth,
+            max_depth,
         } = builder;
 
         let Info { size, children } = get_info(&path);
-        let next_depth = current_depth.saturating_sub(1);
+        let max_depth = max_depth.saturating_sub(1);
 
         let children: Vec<_> = children
             .into_par_iter()
@@ -56,11 +56,11 @@ where
                 name,
                 get_info,
                 join_path,
-                max_depth: next_depth,
+                max_depth,
             })
             .map(Self::from)
             .collect();
 
-        DataTree::dir(name, size, children, current_depth)
+        DataTree::dir(name, size, children, max_depth)
     }
 }

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -38,7 +38,6 @@ use std::fmt::Display;
 ///     direction: Direction::BottomUp,
 ///     bar_alignment: BarAlignment::Right,
 ///     column_width_distribution: ColumnWidthDistribution::total(100),
-///     max_depth: std::num::NonZeroUsize::new(10).unwrap(),
 /// };
 /// println!("{visualizer}");
 /// # }

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -15,7 +15,7 @@ pub use proportion_bar::{ProportionBar, ProportionBarBlock};
 pub use tree::{TreeHorizontalSlice, TreeSkeletalComponent};
 
 use super::{data_tree::DataTree, size};
-use std::{fmt::Display, num::NonZeroUsize};
+use std::fmt::Display;
 
 /// Visualize a [`DataTree`].
 ///
@@ -59,8 +59,6 @@ where
     pub bar_alignment: BarAlignment,
     /// Distribution and total number of characters/blocks can be placed in a line.
     pub column_width_distribution: ColumnWidthDistribution,
-    /// Maximum number of levels that should be visualized.
-    pub max_depth: NonZeroUsize,
 }
 
 mod copy;

--- a/src/visualizer/methods/initial_table.rs
+++ b/src/visualizer/methods/initial_table.rs
@@ -46,7 +46,6 @@ where
 {
     #[derive(Clone)]
     struct Param<Name, NodeData> {
-        remaining_depth: usize,
         index_as_child: usize,
         ancestors: Vec<NodeInfo<Name, NodeData>>,
         preceding_sibling: Option<NodeInfo<Name, NodeData>>,
@@ -69,11 +68,7 @@ where
         Size: size::Size,
         Act: FnMut(&'a DataTree<Name, Size>, Param<&'a Name, Size>) -> ActResult<&'a Name, Size>,
     {
-        if param.remaining_depth == 0 {
-            return None;
-        }
         let ActResult { node_info } = act(tree, param.clone());
-        let remaining_depth = param.remaining_depth - 1;
         let mut preceding_sibling = None;
         for (index_as_child, child) in tree.children().iter().enumerate() {
             let mut ancestors = Vec::with_capacity(param.ancestors.len() + 1);
@@ -83,7 +78,6 @@ where
                 child,
                 act,
                 Param {
-                    remaining_depth,
                     index_as_child,
                     ancestors,
                     preceding_sibling,
@@ -103,18 +97,12 @@ where
             let Param {
                 index_as_child,
                 ancestors,
-                remaining_depth,
                 preceding_sibling,
             } = param;
             let name = node.name();
             let node_data = node.size();
             let row_index = initial_table.len();
-            debug_assert_op!(remaining_depth > 0);
-            let children_count = if remaining_depth != 1 {
-                node.children().len()
-            } else {
-                0
-            };
+            let children_count = node.children().len();
             let fs_size = node.size().into();
             let percentage = if total_fs_size == 0 {
                 "0%".to_string()
@@ -134,7 +122,6 @@ where
                 sibling_count,
                 index_as_child,
                 children_count,
-                remaining_depth,
             };
 
             initial_table.column_width.size_column_width =
@@ -151,7 +138,6 @@ where
             ActResult { node_info }
         },
         Param {
-            remaining_depth: visualizer.max_depth.get(),
             index_as_child: 0,
             ancestors: Vec::new(),
             preceding_sibling: None,

--- a/src/visualizer/methods/node_info.rs
+++ b/src/visualizer/methods/node_info.rs
@@ -8,5 +8,4 @@ pub struct NodeInfo<Name, NodeData> {
     pub sibling_count: NonZeroUsize,
     pub index_as_child: usize,
     pub children_count: usize,
-    pub remaining_depth: usize,
 }

--- a/src/visualizer/methods/tree_table.rs
+++ b/src/visualizer/methods/tree_table.rs
@@ -65,11 +65,7 @@ where
         .map(|initial_row| {
             let child_position =
                 ChildPosition::from_index(initial_row.index_as_child, initial_row.sibling_count);
-            let parenthood = if initial_row.remaining_depth == 0 {
-                Parenthood::Childless
-            } else {
-                Parenthood::from_children_count(initial_row.children_count)
-            };
+            let parenthood = Parenthood::from_children_count(initial_row.children_count);
             let skeletal_component = TreeSkeletalComponent {
                 child_position,
                 parenthood,

--- a/tests/_utils.rs
+++ b/tests/_utils.rs
@@ -153,6 +153,7 @@ where
                 panic!("Unexpected call to report_error: {error:?}")
             }),
             root: root.join(suffix),
+            max_depth: 10,
         }
         .pipe(DataTree::<OsStringDisplay, Size>::from)
         .into_par_sorted(|left, right| left.name().cmp(right.name()))

--- a/tests/cli_errors.rs
+++ b/tests/cli_errors.rs
@@ -18,7 +18,6 @@ use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::{
     collections::BTreeSet,
-    convert::TryInto,
     path::Path,
     process::{Command, Output, Stdio},
 };
@@ -144,7 +143,6 @@ fn fs_errors() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected_stdout = format!("{visualizer}");
     eprintln!("EXPECTED STDOUT:\n{}\n", &expected_stdout);

--- a/tests/cli_errors.rs
+++ b/tests/cli_errors.rs
@@ -133,6 +133,7 @@ fn fs_errors() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_sort_by(|left, right| left.size().cmp(&right.size()).reverse());

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -30,7 +30,7 @@ type SampleTree = DataTree<SampleName, SampleData>;
 
 fn sample_tree() -> SampleTree {
     let dir = |name: &'static str, children: Vec<SampleTree>| {
-        SampleTree::dir(name.to_string(), 1024.into(), children)
+        SampleTree::dir(name.to_string(), 1024.into(), children, 10)
     };
     let file =
         |name: &'static str, size: u64| SampleTree::file(name.to_string(), Bytes::from(size));
@@ -82,6 +82,7 @@ fn json_output() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let expected = builder
         .pipe(DataTree::<_, Bytes>::from)

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -134,7 +134,6 @@ fn json_input() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -58,6 +58,7 @@ impl SampleTree {
                 }
             },
             join_path: |prefix, name| format!("{prefix}{SAMPLE_SEPARATOR}{name}"),
+            max_depth: 10,
         }
         .pipe(DataTree::from)
         .into_par_sorted(|left, right| left.name().as_str().cmp(right.name().as_str()))

--- a/tests/usual_cli.rs
+++ b/tests/usual_cli.rs
@@ -43,6 +43,7 @@ fn total_width() {
         root: workspace.to_path_buf(),
         size_getter: DEFAULT_GET_SIZE,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -81,6 +82,7 @@ fn column_width() {
         root: workspace.to_path_buf(),
         size_getter: DEFAULT_GET_SIZE,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -119,6 +121,7 @@ fn min_ratio_0() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_sort_by(|left, right| left.size().cmp(&right.size()).reverse());
@@ -156,6 +159,7 @@ fn min_ratio() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.1);
@@ -194,6 +198,7 @@ fn max_depth_2() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -232,6 +237,7 @@ fn max_depth_1() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -269,6 +275,7 @@ fn top_down() {
         root: workspace.to_path_buf(),
         size_getter: DEFAULT_GET_SIZE,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -306,6 +313,7 @@ fn align_right() {
         root: workspace.to_path_buf(),
         size_getter: DEFAULT_GET_SIZE,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -343,6 +351,7 @@ fn quantity_apparent_size() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -381,6 +390,7 @@ fn quantity_block_size() {
         root: workspace.to_path_buf(),
         size_getter: GetBlockSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -419,6 +429,7 @@ fn quantity_block_count() {
         root: workspace.to_path_buf(),
         size_getter: GetBlockCount,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -458,6 +469,7 @@ fn bytes_format_plain() {
         root: workspace.to_path_buf(),
         size_getter: GetBlockSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -497,6 +509,7 @@ fn bytes_format_metric() {
         root: workspace.to_path_buf(),
         size_getter: GetBlockSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -536,6 +549,7 @@ fn bytes_format_binary() {
         root: workspace.to_path_buf(),
         size_getter: GetBlockSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -573,6 +587,7 @@ fn path_to_workspace() {
         root: workspace.to_path_buf(),
         size_getter: DEFAULT_GET_SIZE,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+        max_depth: 10,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -615,6 +630,7 @@ fn multiple_names() {
                 root: workspace.to_path_buf().join(name),
                 size_getter: GetApparentSize,
                 reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
+                max_depth: 10,
             };
             let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
             *data_tree.name_mut() = OsStringDisplay::os_string_from(name);
@@ -625,6 +641,7 @@ fn multiple_names() {
                 OsStringDisplay::os_string_from("(total)"),
                 0.into(),
                 children.collect(),
+                10,
             )
         })
         .into_par_sorted(|left, right| left.size().cmp(&right.size()).reverse());

--- a/tests/usual_cli.rs
+++ b/tests/usual_cli.rs
@@ -15,10 +15,7 @@ use parallel_disk_usage::{
 };
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
-use std::{
-    convert::TryInto,
-    process::{Command, Stdio},
-};
+use std::process::{Command, Stdio};
 
 fn stdio(command: Command) -> Command {
     command
@@ -55,7 +52,6 @@ fn total_width() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -94,7 +90,6 @@ fn column_width() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::components(10, 90),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -132,7 +127,6 @@ fn min_ratio_0() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -171,7 +165,6 @@ fn min_ratio() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -210,7 +203,6 @@ fn max_depth_2() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 2.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -249,7 +241,6 @@ fn max_depth_1() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 1.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -287,7 +278,6 @@ fn top_down() {
         direction: Direction::TopDown,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -325,7 +315,6 @@ fn align_right() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Right,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -363,7 +352,6 @@ fn quantity_apparent_size() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -402,7 +390,6 @@ fn quantity_block_size() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -441,7 +428,6 @@ fn quantity_block_count() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -481,7 +467,6 @@ fn bytes_format_plain() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -521,7 +506,6 @@ fn bytes_format_metric() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -561,7 +545,6 @@ fn bytes_format_binary() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -598,7 +581,6 @@ fn path_to_workspace() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();
@@ -652,7 +634,6 @@ fn multiple_names() {
         direction: Direction::BottomUp,
         bar_alignment: BarAlignment::Left,
         column_width_distribution: ColumnWidthDistribution::total(100),
-        max_depth: 10.try_into().unwrap(),
     };
     let expected = format!("{visualizer}");
     let expected = expected.trim_end();

--- a/tests/usual_cli.rs
+++ b/tests/usual_cli.rs
@@ -191,7 +191,7 @@ fn max_depth_2() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
-        max_depth: 10,
+        max_depth: 2,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);
@@ -229,7 +229,7 @@ fn max_depth_1() {
         root: workspace.to_path_buf(),
         size_getter: GetApparentSize,
         reporter: ErrorOnlyReporter::new(ErrorReport::SILENT),
-        max_depth: 10,
+        max_depth: 1,
     };
     let mut data_tree: DataTree<OsStringDisplay, _> = builder.into();
     data_tree.par_cull_insignificant_data(0.01);

--- a/tests/visualizer.rs
+++ b/tests/visualizer.rs
@@ -404,7 +404,7 @@ fn nested_tree<Size: size::Size>(
 ) -> DataTree<&'static str, Size> {
     if let Some((head, tail)) = dir_names.split_first() {
         let child = nested_tree(tail, size_per_dir, file_name, file_size);
-        DataTree::dir(*head, size_per_dir, vec![child])
+        DataTree::dir(*head, size_per_dir, vec![child], 10)
     } else {
         DataTree::file(file_name, file_size)
     }
@@ -650,7 +650,7 @@ fn empty_dir<Size>(inode_size: Size) -> DataTree<&'static str, Size>
 where
     Size: size::Size + Ord + From<u64> + Send,
 {
-    DataTree::dir("empty directory", inode_size, Vec::new()).into_par_sorted(order_tree)
+    DataTree::dir("empty directory", inode_size, Vec::new(), 10).into_par_sorted(order_tree)
 }
 
 test_case! {

--- a/tests/visualizer.rs
+++ b/tests/visualizer.rs
@@ -7,7 +7,7 @@ use parallel_disk_usage::{
     visualizer::{BarAlignment, ColumnWidthDistribution, Direction, Visualizer},
 };
 use pretty_assertions::assert_eq;
-use std::{cmp::Ordering, num::NonZeroUsize};
+use std::cmp::Ordering;
 use text_block_macros::text_block_fnl;
 use zero_copy_pads::Width;
 
@@ -33,10 +33,10 @@ macro_rules! test_case {
         $(#[$attributes])*
         #[test]
         fn $name() {
-            let tree = $tree;
+            let mut tree = $tree;
             let column_width_distribution =
                 ColumnWidthDistribution::$column_width_function($($column_width_arguments),+);
-            let _max_depth = NonZeroUsize::new($max_depth).expect("non-zero max_depth"); // TODO: remove later
+            tree.par_retain(|_, depth| depth + 1 < $max_depth);
             let actual = Visualizer {
                 column_width_distribution,
                 data_tree: &tree,

--- a/tests/visualizer.rs
+++ b/tests/visualizer.rs
@@ -36,9 +36,8 @@ macro_rules! test_case {
             let tree = $tree;
             let column_width_distribution =
                 ColumnWidthDistribution::$column_width_function($($column_width_arguments),+);
-            let max_depth = NonZeroUsize::new($max_depth).expect("non-zero max_depth");
+            let _max_depth = NonZeroUsize::new($max_depth).expect("non-zero max_depth"); // TODO: remove later
             let actual = Visualizer {
-                max_depth,
                 column_width_distribution,
                 data_tree: &tree,
                 bytes_format: $bytes_format,


### PR DESCRIPTION
# Breaking Changes

* `TreeBuilder` and `FsTreeBuilder` now asks for `max_depth`.
* `Visualizer::max_depth` has been removed.
* The types of some `max_depth` fields have been changed from `NonZeroUsize` to `NonZeroU64`.

---

Related: https://github.com/KSXGitHub/parallel-disk-usage/issues/277