### PR TITLE
perf!: do not create copies of dir entries

### DIFF
--- a/src/fs_tree_builder.rs
+++ b/src/fs_tree_builder.rs
@@ -6,7 +6,6 @@ use super::{
     size,
     tree_builder::{Info, TreeBuilder},
 };
-use pipe_trait::Pipe;
 use std::{
     fs::{read_dir, symlink_metadata},
     path::PathBuf,
@@ -99,17 +98,9 @@ where
                         }
                         Ok(entries) => entries,
                     }
-                    .filter_map(|entry| match entry {
-                        Err(error) => {
-                            reporter.report(Event::EncounterError(ErrorReport {
-                                operation: AccessEntry,
-                                path,
-                                error,
-                            }));
-                            None
-                        }
-                        Ok(entry) => entry.file_name().pipe(OsStringDisplay::from).pipe(Some),
-                    })
+                    .flatten()
+                    .map(|entry| entry.file_name())
+                    .map(OsStringDisplay::from)
                     .collect()
                 } else {
                     Vec::new()

--- a/src/reporter/error_report/operation.rs
+++ b/src/reporter/error_report/operation.rs
@@ -5,8 +5,6 @@ pub enum Operation {
     SymlinkMetadata,
     /// Error is caused by calling [`std::fs::read_dir`].
     ReadDirectory,
-    /// Error when trying to access [`std::fs::DirEntry`] of one of the element of [`std::fs::read_dir`].
-    AccessEntry,
 }
 
 impl Operation {
@@ -16,7 +14,6 @@ impl Operation {
         match self {
             SymlinkMetadata => "symlink_metadata",
             ReadDirectory => "read_dir",
-            AccessEntry => "access entry",
         }
     }
 }
@@ -36,5 +33,4 @@ mod test_operation {
 
     name_display!(symlink_metadata, SymlinkMetadata, "symlink_metadata");
     name_display!(read_directory, ReadDirectory, "read_dir");
-    name_display!(access_entry, AccessEntry, "access entry");
 }

--- a/src/tree_builder/info.rs
+++ b/src/tree_builder/info.rs
@@ -1,12 +1,11 @@
 use crate::size;
 use derive_more::From;
-use smart_default::SmartDefault;
 
 /// Information to return from `get_info` of [`super::TreeBuilder`].
-#[derive(Debug, SmartDefault, From)]
-pub struct Info<Name, Size: size::Size> {
+#[derive(Debug, Default, From)]
+pub struct Info<NameIter, Size: size::Size> {
     /// Size associated with given `path`.
     pub size: Size,
     /// Direct descendants of given `path`.
-    pub children: Vec<Name>, // TODO: change this into an iterator
+    pub children: NameIter,
 }


### PR DESCRIPTION
## Breaking Change

* `AccessEntry` has been removed from `error_report::Operation`.
* Generic parameter `Name` of `tree_builder::Info` has been replaced with `NameIter`.
* Generic parameter `Name` of `TreeBuilder` has been replaced with `NameIter`.