### PR TITLE
Fix mismatched_lifetime_syntaxes lint errors

### DIFF
--- a/src/hardlink/hardlink_list/iter.rs
+++ b/src/hardlink/hardlink_list/iter.rs
@@ -11,7 +11,7 @@ pub struct Iter<'a, Size>(DashIter<'a, InodeNumber, Value<Size>>);
 
 impl<Size> HardlinkList<Size> {
     /// Iterate over the recorded entries.
-    pub fn iter(&self) -> Iter<Size> {
+    pub fn iter(&self) -> Iter<'_, Size> {
         self.0.iter().pipe(Iter)
     }
 }

--- a/src/hardlink/hardlink_list/summary.rs
+++ b/src/hardlink/hardlink_list/summary.rs
@@ -183,7 +183,7 @@ impl<Size: size::Size> Display for SummaryDisplay<'_, Size> {
 impl<Size: size::Size> Summary<Size> {
     /// Turns this [`Summary`] into something [displayable](Display).
     #[inline]
-    pub fn display(&self, format: Size::DisplayFormat) -> SummaryDisplay<Size> {
+    pub fn display(&self, format: Size::DisplayFormat) -> SummaryDisplay<'_, Size> {
         SummaryDisplay {
             format,
             summary: self,

--- a/src/hardlink/link_path_list/iter.rs
+++ b/src/hardlink/link_path_list/iter.rs
@@ -8,7 +8,7 @@ pub struct Iter<'a>(slice::Iter<'a, PathBuf>);
 
 impl LinkPathList {
     /// Iterate over the paths inside the list.
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         self.0.iter().pipe(Iter)
     }
 }

--- a/src/visualizer/methods/initial_table.rs
+++ b/src/visualizer/methods/initial_table.rs
@@ -38,7 +38,7 @@ pub(super) type InitialTable<Name, NodeData> =
     Table<InitialRow<Name, NodeData>, InitialColumnWidth>;
 
 pub(super) fn render_initial<Name, Size>(
-    visualizer: Visualizer<Name, Size>,
+    visualizer: Visualizer<'_, Name, Size>,
 ) -> InitialTable<&'_ Name, Size>
 where
     Name: Display,


### PR DESCRIPTION
## Problem

On Rust 1.89, the [mismatched_lifetime_syntaxes](https://github.com/rust-lang/rust/pull/138677) lint was added to the compiler. Because `parallel-disk-usage` disables all warnings, compiling `pdu` on Rust 1.89 results in a hard compiler error:

<img width="2500" height="1540" alt="image" src="https://github.com/user-attachments/assets/db9f9f5b-5310-4212-938e-aa773ddf4143" />

## Solution

Following suggestions from `rustc`, it's trivial to add in the missing annotations:

<img width="2500" height="1540" alt="image" src="https://github.com/user-attachments/assets/f7e3aa8b-b092-499a-ac20-b1f1e526faa7" />

<img width="2500" height="1540" alt="image" src="https://github.com/user-attachments/assets/de2f3ca0-660c-498d-acef-78a9668af033" />

---

P.S. Super great tool you've made here! Thanks for all the hard work you do to maintain it. `pdu` is definitely the tool I reach for when my WSL at work gets a little too full :) 