### PR TITLE
ci(deploy): trusted publishing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -472,6 +472,7 @@ jobs:
     environment: release
 
     permissions:
+      contents: read
       id-token: write # needed for crates.io Trusted Publishing
 
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -469,6 +469,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    environment: release
+
     permissions:
       id-token: write # needed for crates.io Trusted Publishing
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -469,6 +469,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write # needed for crates.io Trusted Publishing
+
     steps:
       - uses: actions/checkout@v6
 
@@ -479,11 +482,14 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > $installer
           bash $installer --default-toolchain $(cat rust-toolchain) -y
 
-      - name: Login
-        run: cargo login ${{ secrets.CRATE_AUTH_TOKEN }}
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
 
       - name: Publish
         run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   competing_benchmark:
     name: Benchmark


### PR DESCRIPTION
## Summary

Switch crates.io publishing from a long-lived API token to [Trusted Publishing](https://crates.io/docs/trusted-publishing) (OIDC).

- The `publish_cargo_crate` job now uses `rust-lang/crates-io-auth-action@v1` to exchange a GitHub OIDC token for a short-lived crates.io token at publish time, instead of `cargo login` with the `CRATE_AUTH_TOKEN` secret. The token is auto-revoked when the job ends, so no long-lived credential lives in the repository.
- The job is bound to a `release` GitHub Actions environment so environment protection rules (e.g. required reviewers, tag restrictions) gate token issuance.

https://claude.ai/code/session_013tt2ucFPTnTnGGM1RLG19m