### PR TITLE
fix!: rejects `NaN` in `Fraction`

### DIFF
--- a/src/args/fraction.rs
+++ b/src/args/fraction.rs
@@ -18,12 +18,18 @@ pub enum ConversionError {
     /// Provided value is less than 0.
     #[display("less than 0")]
     LowerBound,
+    /// Provided value is `NaN`.
+    #[display("not a number")]
+    NotANumber,
 }
 
 impl Fraction {
     /// Create a [`Fraction`].
     pub fn new(value: f32) -> Result<Self, ConversionError> {
         use ConversionError::*;
+        if value.is_nan() {
+            return Err(NotANumber);
+        }
         if value >= 1.0 {
             return Err(UpperBound);
         }

--- a/tests/args_fraction.rs
+++ b/tests/args_fraction.rs
@@ -49,6 +49,18 @@ fn equal_to_one() {
 }
 
 #[test]
+fn not_a_number() {
+    let actual_error = "NaN".parse::<Fraction>().expect_err("cause nan error");
+    let actual_message = actual_error.to_string();
+    let expected_error = Conversion(NotANumber);
+    let expected_message = "not a number".to_string();
+    assert_eq!(
+        (actual_error, actual_message),
+        (expected_error, expected_message),
+    );
+}
+
+#[test]
 fn invalid_float_literal() {
     let actual = "a"
         .parse::<Fraction>()


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/parallel-disk-usage/issues/425>.

## Problem

`Fraction::new` is documented to hold a value greater than or equal to 0 and less than 1, but it silently accepted `NaN`. Both bounds checks (`value >= 1.0` and `value < 0.0`) are `false` for `NaN`, so the value slipped through to the constructor. This was reachable from the CLI via `--min-ratio=NaN`.

## Change

- Add an explicit `is_nan()` check at the start of `Fraction::new`.
- Add a `NotANumber` variant to `ConversionError` (displayed as "not a number") so the invalid value is rejected at the boundary rather than relying on every downstream consumer to special-case `NaN`.
- Add a test covering `"NaN".parse::<Fraction>()`.

This is a breaking change: `Fraction::new(NaN)` now returns `Err(NotANumber)` instead of `Ok`, and the public `ConversionError` enum gains a new variant.