### PR TITLE
Enable LTO and reduce code generation units for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,7 @@ normalize-path = "0.2.1"
 pretty_assertions = "1.4.1"
 rand = "0.10.1"
 which = "8.0.2"
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
According to [The rustc book](https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units):

> ## codegen-units
> This flag controls the maximum number of code generation units the crate is split into. It takes an integer greater than 0.
>
> When a crate is split into multiple codegen units, LLVM is able to process them in parallel. Increasing parallelism may speed up compile times, but may also produce slower code. **Setting this to 1 may improve the performance of generated code, but may be slower to compile.**
>
> The default value, if not specified, is 16 for non-incremental builds. For incremental builds the default is 256 which allows caching to be more granular.