### PR TITLE
refactor: `self`-less capability trait dependency injection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,7 +360,7 @@ The upstream guide names the opposite smell as well: a function that carries a `
 - The generic parameter is named `Sys`.
 - The single production provider is named `Host`. It lives in `src/app/host.rs` and delegates every capability to the real operating system.
 - A capability trait is named for the action it performs, such as `GetDiskKind`, `Canonicalize`, or `IsRealDir`.
-- A fake is named for its behavior, such as `EmptySysfs` for a provider whose sysfs contains nothing or `SymlinkFs` for one that resolves a fixed table of symbolic links.
+- A fake is named for its behavior, such as `SymlinkFs` for one that resolves a fixed table of symbolic links, or for what it stands in for, such as `FakeDisk` for a fake through which disk detection is tested.
 
 ### One trait per capability
 
@@ -430,7 +430,7 @@ fn some_reclassification_case() {
 }
 ```
 
-A fake that holds no state is the one exception. Because it has nothing to race on, it may sit at module scope and be shared, in the manner of a frozen clock. `EmptySysfs` in `src/app/hdd/test.rs` and `SymlinkFs` in `src/app/overlapping_arguments/test_remove_overlapping_paths.rs` are stateless, so each is declared once and reused across the tests in its module. Small stateless helpers, such as a fake-disk constructor or a symlink resolver, may likewise stay at module scope.
+A fake that holds no state is the one exception. Because it has nothing to race on, it may sit at module scope and be shared, in the manner of a frozen clock. `SymlinkFs` in `src/app/overlapping_arguments/test_remove_overlapping_paths.rs` is stateless, so it is declared once and reused across the tests in its module. Small stateless helpers, such as a symlink resolver, may likewise stay at module scope.
 
 ## Unit Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,9 +358,9 @@ The opposite is also a smell: a function that carries a `Sys` generic but is onl
 ### Naming
 
 - The generic parameter is named `Sys`.
-- The single production provider is named `Host`. It lives in `src/app/host.rs` and delegates every capability to the real operating system.
+- The single production provider is named `Host`. It delegates every capability to the real operating system.
 - A capability trait is named for the action it performs, such as `GetDiskKind`, `Canonicalize`, or `IsRealDir`.
-- A fake is named for its behavior, such as `SymlinkFs` for one that resolves a fixed table of symbolic links, or for what it stands in for, such as `FakeDisk` for a fake through which disk detection is tested.
+- A fake is named for its behavior, such as a fake filesystem that resolves a fixed table of symbolic links, or for what it stands in for, such as a fake through which disk detection is tested.
 
 ### One trait per capability
 
@@ -380,7 +380,7 @@ pub trait ReadLink {
 }
 ```
 
-Keep capabilities at the level of leaf primitives, each mirroring a single standard-library function, and compose higher-level behavior as ordinary free functions on top of them. The pure `starts_with` prefix check in `overlapping_arguments` is a plain method call inside the algorithm rather than a capability, because it touches no side effect.
+Keep capabilities at the level of leaf primitives, each mirroring a single standard-library function, and compose higher-level behavior as ordinary free functions on top of them. A pure computation such as a path-prefix check is a plain method call inside the algorithm rather than a capability, because it touches no side effect.
 
 ### Self-less methods and a stateless provider
 
@@ -406,13 +406,13 @@ impl GetMountPoint for Host {
 }
 ```
 
-Production call sites name the provider explicitly through a turbofish, such as `any_path_is_in_hdd::<Host>(&files, &disks)` and `remove_overlapping_paths::<Host>(&mut files)`, so the production choice is visible at the call site rather than left to inference.
+Production call sites name the provider explicitly through a turbofish, such as `some_operation::<Host>(&files)`, so the production choice is visible at the call site rather than left to inference.
 
 ### Fakes and their state are function-scoped
 
 Each test defines its own fake `struct`, and, when the fake needs state, its own `static` for that state, both inside the test body. Rust allows `static`, `struct`, `const`, and `impl` items inside a function, and a function-local `static` still has `'static` lifetime, so each test stays self-contained and shares nothing with the others. Do not hoist fixture state to a module-level or global `static` to share it across tests, and do not reach for `thread_local!` to paper over such sharing.
 
-The reclassification tests in `src/app/hdd/test_linux.rs` follow this rule. Each generated test declares its own `DEVICES` and `DRIVERS` tables as `static` items inside the test function, and its own `Fs` fake next to them.
+For example, a test that needs specific host state declares its fixture tables as `static` items inside the test function, with its fake alongside them:
 
 ```rust
 #[test]
@@ -430,7 +430,7 @@ fn some_reclassification_case() {
 }
 ```
 
-A fake that holds no state is the one exception. Because it has nothing to race on, it may sit at module scope and be shared, in the manner of a frozen clock. `SymlinkFs` in `src/app/overlapping_arguments/test_remove_overlapping_paths.rs` is stateless, so it is declared once and reused across the tests in its module. Small stateless helpers, such as a symlink resolver, may likewise stay at module scope.
+A fake that holds no state is the one exception. Because it has nothing to race on, it may sit at module scope and be shared, in the manner of a frozen clock. A stateless fake that only reads a fixed table of module constants is such a case, so it may be declared once and reused across the tests in its module. Small stateless helpers, such as a symlink resolver, may likewise stay at module scope.
 
 ## Unit Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,6 +341,97 @@ ExitCode::from(match self {
 })
 ```
 
+## Dependency Injection for Tests
+
+Some code paths cannot be reached by a real fixture. Reading a [`sysinfo::Disk`], which has no public constructor, probing sysfs under `/sys/block`, resolving symbolic links, and canonicalizing paths against the live filesystem are all examples. For these paths this project adopts the dependency-injection-for-tests pattern from [pnpm's Rust code style guide](https://github.com/pnpm/pnpm/blob/main/pacquet/CODE_STYLE_GUIDE.md#dependency-injection-for-tests). The side effects a function needs are expressed as capability traits, production supplies a real provider, and each test supplies a fake.
+
+### When to reach for it
+
+The default remains real fixtures, such as a temporary directory or an integration test that runs the built binary. Reach for a dependency-injection seam only for paths that a real fixture cannot reach portably or deterministically.
+
+- Values the standard library and third-party crates will not let a test construct, such as a [`sysinfo::Disk`].
+- Host state that a test cannot stage on demand, such as the sysfs block-device tree or a specific arrangement of symbolic links.
+- Filesystem error branches that the host will not reproduce on request.
+
+The upstream guide names the opposite smell as well: a function that carries a `Sys` generic but is only ever exercised through real fixtures is over-designed. If no test substitutes a fake for the seam, remove the generic and call the real operation directly.
+
+### Naming
+
+- The generic parameter is named `Sys`.
+- The single production provider is named `Host`. It lives in `src/app/host.rs` and delegates every capability to the real operating system.
+- A capability trait is named for the action it performs, such as `GetDiskKind`, `Canonicalize`, or `IsRealDir`.
+- A fake is named for its behavior, such as `EmptySysfs` for a provider whose sysfs contains nothing or `SymlinkFs` for one that resolves a fixed table of symbolic links.
+
+### One trait per capability
+
+Each capability is its own trait with a single method. A function then binds only the capabilities it actually consumes. Carry those capabilities as a single `Sys` generic with several bounds rather than one generic per capability, so call sites stay short and a fake only implements the methods the function under test exercises.
+
+```rust
+pub trait Canonicalize {
+    fn canonicalize(path: &Path) -> io::Result<PathBuf>;
+}
+
+pub trait PathExists {
+    fn path_exists(path: &Path) -> bool;
+}
+
+pub trait ReadLink {
+    fn read_link(path: &Path) -> io::Result<PathBuf>;
+}
+```
+
+Keep capabilities at the level of leaf primitives, each mirroring a single standard-library function, and compose higher-level behavior as ordinary free functions on top of them. The pure `starts_with` prefix check in `overlapping_arguments` is a plain method call inside the algorithm rather than a capability, because it touches no side effect.
+
+### Self-less methods and a stateless provider
+
+The provider holds no state of its own, so every capability method is an associated function that takes no `&self`. The disk value the disk-reading capabilities operate on is exposed as an associated type, so production reads a real [`sysinfo::Disk`] while a test substitutes a lightweight stand-in that the provider chooses.
+
+```rust
+pub trait DiskSource {
+    type Disk;
+}
+
+pub trait GetMountPoint: DiskSource {
+    fn get_mount_point(disk: &Self::Disk) -> &Path;
+}
+
+impl DiskSource for Host {
+    type Disk = sysinfo::Disk;
+}
+
+impl GetMountPoint for Host {
+    fn get_mount_point(disk: &Self::Disk) -> &Path {
+        disk.mount_point()
+    }
+}
+```
+
+Production call sites name the provider explicitly through a turbofish, such as `any_path_is_in_hdd::<Host>(&files, &disks)` and `remove_overlapping_paths::<Host>(&mut files)`, so the production choice is visible at the call site rather than left to inference.
+
+### Fakes and their state are function-scoped
+
+Each test defines its own fake `struct`, and, when the fake needs state, its own `static` for that state, both inside the test body. Rust allows `static`, `struct`, `const`, and `impl` items inside a function, and a function-local `static` still has `'static` lifetime, so each test stays self-contained and shares nothing with the others. Do not hoist fixture state to a module-level or global `static` to share it across tests, and do not reach for `thread_local!` to paper over such sharing.
+
+The reclassification tests in `src/app/hdd/test_linux.rs` follow this rule. Each generated test declares its own `DEVICES` and `DRIVERS` tables as `static` items inside the test function, and its own `Fs` fake next to them.
+
+```rust
+#[test]
+fn some_reclassification_case() {
+    static DEVICES: &[&str] = &["/sys/block/vda"];
+    static DRIVERS: &[(&str, &str)] = &[("/sys/block/vda/device/driver", "virtio_blk")];
+
+    struct Fs;
+    impl PathExists for Fs {
+        fn path_exists(path: &Path) -> bool {
+            DEVICES.iter().any(|dev| path == Path::new(*dev))
+        }
+    }
+    // ... the remaining capabilities, then the assertion ...
+}
+```
+
+A fake that holds no state is the one exception. Because it has nothing to race on, it may sit at module scope and be shared, in the manner of a frozen clock. `EmptySysfs` in `src/app/hdd/test.rs` and `SymlinkFs` in `src/app/overlapping_arguments/test_remove_overlapping_paths.rs` are stateless, so each is declared once and reused across the tests in its module. Small stateless helpers, such as a fake-disk constructor or a symlink resolver, may likewise stay at module scope.
+
 ## Unit Tests
 
 A unit-test module may either sit inline as `mod tests { ... }` in its parent or live in a dedicated external `tests` submodule. Use the inline form for short test modules. Once the block becomes long enough to obscure the surrounding module, move the tests into an external file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,7 +343,7 @@ ExitCode::from(match self {
 
 ## Dependency Injection for Tests
 
-Some code paths cannot be reached by a real fixture. Reading a `sysinfo::Disk`, which has no public constructor, probing sysfs under `/sys/block`, resolving symbolic links, and canonicalizing paths against the live filesystem are all examples. For these paths this project adopts the dependency-injection-for-tests pattern from [pnpm's Rust code style guide](https://github.com/pnpm/pnpm/blob/main/pacquet/CODE_STYLE_GUIDE.md#dependency-injection-for-tests). The side effects a function needs are expressed as capability traits, production supplies a real provider, and each test supplies a fake.
+Some code paths cannot be reached by a real fixture. Reading a `sysinfo::Disk`, which has no public constructor, probing sysfs under `/sys/block`, resolving symbolic links, and canonicalizing paths against the live filesystem are all examples. For these paths this project uses a dependency-injection-for-tests pattern: the side effects a function needs are expressed as capability traits, production supplies a real provider, and each test supplies a fake.
 
 ### When to reach for it
 
@@ -353,7 +353,7 @@ The default remains real fixtures, such as a temporary directory or an integrati
 - Host state that a test cannot stage on demand, such as the sysfs block-device tree or a specific arrangement of symbolic links.
 - Filesystem error branches that the host will not reproduce on request.
 
-The upstream guide names the opposite smell as well: a function that carries a `Sys` generic but is only ever exercised through real fixtures is over-designed. If no test substitutes a fake for the seam, remove the generic and call the real operation directly.
+The opposite is also a smell: a function that carries a `Sys` generic but is only ever exercised through real fixtures is over-designed. If no test substitutes a fake for the seam, remove the generic and call the real operation directly.
 
 ### Naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,13 +343,13 @@ ExitCode::from(match self {
 
 ## Dependency Injection for Tests
 
-Some code paths cannot be reached by a real fixture. Reading a [`sysinfo::Disk`], which has no public constructor, probing sysfs under `/sys/block`, resolving symbolic links, and canonicalizing paths against the live filesystem are all examples. For these paths this project adopts the dependency-injection-for-tests pattern from [pnpm's Rust code style guide](https://github.com/pnpm/pnpm/blob/main/pacquet/CODE_STYLE_GUIDE.md#dependency-injection-for-tests). The side effects a function needs are expressed as capability traits, production supplies a real provider, and each test supplies a fake.
+Some code paths cannot be reached by a real fixture. Reading a `sysinfo::Disk`, which has no public constructor, probing sysfs under `/sys/block`, resolving symbolic links, and canonicalizing paths against the live filesystem are all examples. For these paths this project adopts the dependency-injection-for-tests pattern from [pnpm's Rust code style guide](https://github.com/pnpm/pnpm/blob/main/pacquet/CODE_STYLE_GUIDE.md#dependency-injection-for-tests). The side effects a function needs are expressed as capability traits, production supplies a real provider, and each test supplies a fake.
 
 ### When to reach for it
 
 The default remains real fixtures, such as a temporary directory or an integration test that runs the built binary. Reach for a dependency-injection seam only for paths that a real fixture cannot reach portably or deterministically.
 
-- Values the standard library and third-party crates will not let a test construct, such as a [`sysinfo::Disk`].
+- Values the standard library and third-party crates will not let a test construct, such as a `sysinfo::Disk`.
 - Host state that a test cannot stage on demand, such as the sysfs block-device tree or a specific arrangement of symbolic links.
 - Filesystem error branches that the host will not reproduce on request.
 
@@ -384,7 +384,7 @@ Keep capabilities at the level of leaf primitives, each mirroring a single stand
 
 ### Self-less methods and a stateless provider
 
-The provider holds no state of its own, so every capability method is an associated function that takes no `&self`. The disk value the disk-reading capabilities operate on is exposed as an associated type, so production reads a real [`sysinfo::Disk`] while a test substitutes a lightweight stand-in that the provider chooses.
+The provider holds no state of its own, so every capability method is an associated function that takes no `&self`. The disk value the disk-reading capabilities operate on is exposed as an associated type, so production reads a real `sysinfo::Disk` while a test substitutes a lightweight stand-in that the provider chooses.
 
 ```rust
 pub trait DiskSource {

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,11 +13,12 @@ use crate::visualizer::{BarAlignment, ColumnWidthDistribution, Direction, Visual
 use crate::{hardlink, size};
 use clap::Parser;
 use hdd::any_path_is_in_hdd;
+use host::Host;
 use pipe_trait::Pipe;
 use std::io::stdin;
 use std::time::Duration;
 use sub::JsonOutputParam;
-use sysinfo::{Disk, Disks};
+use sysinfo::Disks;
 
 #[cfg(unix)]
 use crate::get_size::{GetBlockCount, GetBlockSize};
@@ -185,7 +186,7 @@ impl App {
         let threads = match self.args.threads {
             Threads::Auto => {
                 let disks = Disks::new_with_refreshed_list();
-                any_path_is_in_hdd::<Disk, hdd::RealFs>(&self.args.files, &disks).then(|| {
+                any_path_is_in_hdd::<Host>(&self.args.files, &disks).then(|| {
                     eprintln!("warning: HDD detected, the thread limit will be set to 1");
                     eprintln!("hint: You can pass --threads=max disable this behavior");
                     1
@@ -206,8 +207,8 @@ impl App {
             // Hardlinks deduplication doesn't work properly if there are more than 1 paths pointing to
             // the same tree or if a path points to a subtree of another path. Therefore, we must find
             // and remove such overlapping paths before they cause problems.
-            use overlapping_arguments::{RealApi, remove_overlapping_paths};
-            remove_overlapping_paths::<RealApi>(&mut self.args.files);
+            use overlapping_arguments::remove_overlapping_paths;
+            remove_overlapping_paths::<Host>(&mut self.args.files);
         }
 
         let report_error = if self.args.silent_errors {
@@ -379,5 +380,6 @@ impl App {
 }
 
 mod hdd;
+mod host;
 mod mount_point;
 mod overlapping_arguments;

--- a/src/app/hdd.rs
+++ b/src/app/hdd.rs
@@ -170,8 +170,8 @@ where
 /// in [`is_hdd`] never matches, so this function is effectively a no-op.
 ///
 /// If `sysinfo` ever gains accurate disk-kind detection on these platforms,
-/// this function should be revisited — virtual disks on macOS (e.g. virtio
-/// in QEMU) or FreeBSD (e.g. virtio-blk) could face the same misclassification.
+/// this function should be revisited. Virtual disks on macOS (e.g. virtio in
+/// QEMU) or FreeBSD (e.g. virtio-blk) could then face the same misclassification.
 #[cfg(not(target_os = "linux"))]
 fn reclassify_virtual_hdd<Sys>(kind: DiskKind, _: &str) -> DiskKind
 where

--- a/src/app/hdd.rs
+++ b/src/app/hdd.rs
@@ -1,3 +1,4 @@
+use super::host::Host;
 use super::mount_point::find_mount_point;
 use std::ffi::OsStr;
 use std::fs::canonicalize;
@@ -10,61 +11,126 @@ use pipe_trait::Pipe;
 #[cfg(target_os = "linux")]
 use std::borrow::Cow;
 
-/// Mockable interface to [`sysinfo::Disk`] methods.
+/// The disk value that the disk-reading capabilities operate on.
 ///
-/// Each method delegates to a corresponding [`sysinfo::Disk`] method,
-/// enabling dependency injection for testing.
-pub trait DiskApi {
-    fn get_disk_kind(&self) -> DiskKind;
-    fn get_disk_name(&self) -> &OsStr;
-    fn get_mount_point(&self) -> &Path;
+/// The concrete disk type is exposed as an associated type so that production
+/// can read a real [`sysinfo::Disk`] while a test substitutes a lightweight
+/// stand-in carrying only the fields the test needs. The disk type is chosen
+/// by the provider rather than by each call site.
+pub trait DiskSource {
+    /// The disk value that the capabilities below read from.
+    type Disk;
 }
 
-/// Mockable interface to filesystem operations.
-///
-/// Abstracts system calls like [`canonicalize`], [`Path::exists`], and
-/// [`std::fs::read_link`] so tests can substitute an in-memory fake.
-pub trait FsApi {
+/// Capability: read the [`DiskKind`] of a disk.
+pub trait GetDiskKind: DiskSource {
+    fn get_disk_kind(disk: &Self::Disk) -> DiskKind;
+}
+
+/// Capability: read the device name of a disk.
+pub trait GetDiskName: DiskSource {
+    fn get_disk_name(disk: &Self::Disk) -> &OsStr;
+}
+
+/// Capability: read the mount point of a disk.
+pub trait GetMountPoint: DiskSource {
+    fn get_mount_point(disk: &Self::Disk) -> &Path;
+}
+
+/// Capability: resolve a path to its canonical form, mirroring [`std::fs::canonicalize`].
+pub trait Canonicalize {
     fn canonicalize(path: &Path) -> io::Result<PathBuf>;
-    #[cfg(target_os = "linux")]
+}
+
+/// Capability: check whether a path exists, mirroring [`Path::exists`].
+#[cfg(target_os = "linux")]
+pub trait PathExists {
     fn path_exists(path: &Path) -> bool;
-    #[cfg(target_os = "linux")]
+}
+
+/// Capability: read a symbolic link, mirroring [`std::fs::read_link`].
+#[cfg(target_os = "linux")]
+pub trait ReadLink {
     fn read_link(path: &Path) -> io::Result<PathBuf>;
 }
 
-/// Implementation of [`FsApi`] that interacts with the real system.
-pub struct RealFs;
+/// The capabilities the HDD-detection functions require.
+///
+/// This is a bound alias over the individual capability traits above, not an
+/// umbrella capability of its own. It declares no method, and every side
+/// effect still lives in its own single-method trait. It exists only so the
+/// requirement, which varies by platform, is written once rather than repeated
+/// on [`is_hdd`], [`path_is_in_hdd`], and [`any_path_is_in_hdd`].
+///
+/// On Linux the detection additionally probes sysfs to reclassify virtual
+/// block devices, so it also needs [`PathExists`] and [`ReadLink`]. On other
+/// platforms the reclassification is a no-op, so those capabilities are neither
+/// required nor defined.
+#[cfg(target_os = "linux")]
+pub trait HddDetection:
+    GetDiskKind + GetDiskName + GetMountPoint + Canonicalize + PathExists + ReadLink
+{
+}
 
-impl DiskApi for Disk {
-    #[inline]
-    fn get_disk_kind(&self) -> DiskKind {
-        self.kind()
-    }
+#[cfg(target_os = "linux")]
+impl<Sys> HddDetection for Sys where
+    Sys: GetDiskKind + GetDiskName + GetMountPoint + Canonicalize + PathExists + ReadLink
+{
+}
 
-    #[inline]
-    fn get_disk_name(&self) -> &OsStr {
-        self.name()
-    }
+/// The capabilities the HDD-detection functions require.
+///
+/// See the Linux definition of this trait for the full explanation. On this
+/// platform the virtual-disk reclassification is a no-op, so only the
+/// disk-reading capabilities and [`Canonicalize`] are needed.
+#[cfg(not(target_os = "linux"))]
+pub trait HddDetection: GetDiskKind + GetDiskName + GetMountPoint + Canonicalize {}
 
+#[cfg(not(target_os = "linux"))]
+impl<Sys> HddDetection for Sys where Sys: GetDiskKind + GetDiskName + GetMountPoint + Canonicalize {}
+
+impl DiskSource for Host {
+    type Disk = Disk;
+}
+
+impl GetDiskKind for Host {
     #[inline]
-    fn get_mount_point(&self) -> &Path {
-        self.mount_point()
+    fn get_disk_kind(disk: &Self::Disk) -> DiskKind {
+        disk.kind()
     }
 }
 
-impl FsApi for RealFs {
+impl GetDiskName for Host {
+    #[inline]
+    fn get_disk_name(disk: &Self::Disk) -> &OsStr {
+        disk.name()
+    }
+}
+
+impl GetMountPoint for Host {
+    #[inline]
+    fn get_mount_point(disk: &Self::Disk) -> &Path {
+        disk.mount_point()
+    }
+}
+
+impl Canonicalize for Host {
     #[inline]
     fn canonicalize(path: &Path) -> io::Result<PathBuf> {
         canonicalize(path)
     }
+}
 
-    #[cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
+impl PathExists for Host {
     #[inline]
     fn path_exists(path: &Path) -> bool {
         path.exists()
     }
+}
 
-    #[cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
+impl ReadLink for Host {
     #[inline]
     fn read_link(path: &Path) -> io::Result<PathBuf> {
         std::fs::read_link(path)
@@ -83,12 +149,15 @@ const VIRTUAL_DISK_KIND: DiskKind = DiskKind::Unknown(-1);
 /// This function checks the block device's driver via sysfs and reclassifies
 /// known virtual drivers as `Unknown` instead of `HDD`.
 #[cfg(target_os = "linux")]
-fn reclassify_virtual_hdd<Fs: FsApi>(kind: DiskKind, disk_name: &str) -> DiskKind {
+fn reclassify_virtual_hdd<Sys>(kind: DiskKind, disk_name: &str) -> DiskKind
+where
+    Sys: Canonicalize + PathExists + ReadLink,
+{
     if kind != DiskKind::HDD {
         return kind;
     }
-    if let Some(block_dev) = extract_block_device_name::<Fs>(disk_name)
-        && is_virtual_block_device::<Fs>(&block_dev)
+    if let Some(block_dev) = extract_block_device_name::<Sys>(disk_name)
+        && is_virtual_block_device::<Sys>(&block_dev)
     {
         return VIRTUAL_DISK_KIND;
     }
@@ -104,7 +173,7 @@ fn reclassify_virtual_hdd<Fs: FsApi>(kind: DiskKind, disk_name: &str) -> DiskKin
 /// this function should be revisited — virtual disks on macOS (e.g. virtio
 /// in QEMU) or FreeBSD (e.g. virtio-blk) could face the same misclassification.
 #[cfg(not(target_os = "linux"))]
-fn reclassify_virtual_hdd<Fs: FsApi>(kind: DiskKind, _: &str) -> DiskKind {
+fn reclassify_virtual_hdd<Sys>(kind: DiskKind, _: &str) -> DiskKind {
     kind
 }
 
@@ -126,8 +195,8 @@ fn reclassify_virtual_hdd<Fs: FsApi>(kind: DiskKind, _: &str) -> DiskKind {
 /// Fixing this would require walking `/sys/block/dm-*/slaves/` to discover
 /// the real backing device(s). That introduces three problems:
 ///
-/// 1. [`FsApi`] would need a `read_dir` method, expanding the trait and
-///    every mock implementation.
+/// 1. A `read_dir` capability would be needed, expanding the provider and
+///    every test fake.
 /// 2. The slave chain can be recursive (`dm` on `dm`, e.g. LUKS on LVM),
 ///    requiring unbounded traversal.
 /// 3. A `dm` device can have multiple slaves (stripes, mirrors). A policy
@@ -137,15 +206,18 @@ fn reclassify_virtual_hdd<Fs: FsApi>(kind: DiskKind, _: &str) -> DiskKind {
 /// Given the complexity and the relative importance of the auto HDD detection feature,
 /// we have chosen to ignore it.
 #[cfg(target_os = "linux")]
-fn extract_block_device_name<Fs: FsApi>(device_path: &str) -> Option<Cow<'_, str>> {
+fn extract_block_device_name<Sys>(device_path: &str) -> Option<Cow<'_, str>>
+where
+    Sys: Canonicalize + PathExists,
+{
     if !device_path.starts_with("/dev/mapper/") && !device_path.starts_with("/dev/root") {
         let block_dev = parse_block_device_name(device_path)?;
         return block_dev
-            .pipe(validate_block_device::<Fs>)
+            .pipe(validate_block_device::<Sys>)
             .map(Cow::Borrowed);
     }
 
-    let canon_device_path = Fs::canonicalize(Path::new(device_path)).ok()?;
+    let canon_device_path = Sys::canonicalize(Path::new(device_path)).ok()?;
     let canon_device_path = canon_device_path.to_str()?;
     if canon_device_path == device_path {
         return None;
@@ -154,7 +226,7 @@ fn extract_block_device_name<Fs: FsApi>(device_path: &str) -> Option<Cow<'_, str
     // Safe to recurse: `canonicalize` resolves all symlinks, so the
     // canonical path will not start with `/dev/mapper/` or `/dev/root`.
     canon_device_path
-        .pipe(extract_block_device_name::<Fs>)
+        .pipe(extract_block_device_name::<Sys>)
         .map(Cow::into_owned) // must copy-allocate because `canon_device_path` is locally owned
         .map(Cow::Owned)
 }
@@ -201,11 +273,14 @@ fn parse_block_device_name(device_path: &str) -> Option<&str> {
 ///
 /// Returns `Some(block_dev)` if `/sys/block/<block_dev>` exists, `None` otherwise.
 #[cfg(target_os = "linux")]
-fn validate_block_device<Fs: FsApi>(block_dev: &str) -> Option<&str> {
+fn validate_block_device<Sys>(block_dev: &str) -> Option<&str>
+where
+    Sys: PathExists,
+{
     "/sys/block"
         .pipe(Path::new)
         .join(block_dev)
-        .pipe_as_ref(Fs::path_exists)
+        .pipe_as_ref(Sys::path_exists)
         .then_some(block_dev)
 }
 
@@ -214,13 +289,16 @@ fn validate_block_device<Fs: FsApi>(block_dev: &str) -> Option<&str> {
 /// Reads the driver symlink at `/sys/block/<dev>/device/driver` and checks
 /// if it matches known virtual block device drivers.
 #[cfg(target_os = "linux")]
-fn is_virtual_block_device<Fs: FsApi>(block_dev: &str) -> bool {
+fn is_virtual_block_device<Sys>(block_dev: &str) -> bool
+where
+    Sys: ReadLink,
+{
     let driver_path = "/sys/block"
         .pipe(Path::new)
         .join(block_dev)
         .join("device/driver");
 
-    let Ok(target) = Fs::read_link(&driver_path) else {
+    let Ok(target) = Sys::read_link(&driver_path) else {
         return false;
     };
 
@@ -241,34 +319,43 @@ fn is_virtual_block_device<Fs: FsApi>(block_dev: &str) -> bool {
 }
 
 /// Check if any path is in any HDD.
-pub fn any_path_is_in_hdd<Disk: DiskApi, Fs: FsApi>(paths: &[PathBuf], disks: &[Disk]) -> bool {
+pub fn any_path_is_in_hdd<Sys>(paths: &[PathBuf], disks: &[Sys::Disk]) -> bool
+where
+    Sys: HddDetection,
+{
     paths
         .iter()
-        .filter_map(|file| Fs::canonicalize(file).ok())
-        .any(|path| path_is_in_hdd::<Disk, Fs>(&path, disks))
+        .filter_map(|file| Sys::canonicalize(file).ok())
+        .any(|path| path_is_in_hdd::<Sys>(&path, disks))
 }
 
 /// Check if path is in any HDD.
 ///
 /// Applies [`reclassify_virtual_hdd`] to each disk's reported kind to work
 /// around virtual block devices being falsely reported as HDDs on Linux.
-fn path_is_in_hdd<Disk: DiskApi, Fs: FsApi>(path: &Path, disks: &[Disk]) -> bool {
-    let mount_point = find_mount_point(path, disks.iter().map(Disk::get_mount_point));
+fn path_is_in_hdd<Sys>(path: &Path, disks: &[Sys::Disk]) -> bool
+where
+    Sys: HddDetection,
+{
+    let mount_point = find_mount_point(path, disks.iter().map(Sys::get_mount_point));
     let Some(mount_point) = mount_point else {
         return false;
     };
     disks
         .iter()
-        .filter(|disk| disk.get_mount_point() == mount_point)
-        .any(is_hdd::<Fs>)
+        .filter(|disk| Sys::get_mount_point(disk) == mount_point)
+        .any(|disk| is_hdd::<Sys>(disk))
 }
 
 /// Check if a disk is an HDD after applying platform-specific corrections.
-fn is_hdd<Fs: FsApi>(disk: &impl DiskApi) -> bool {
-    let kind = disk.get_disk_kind();
-    let name = disk.get_disk_name().to_str();
+fn is_hdd<Sys>(disk: &Sys::Disk) -> bool
+where
+    Sys: HddDetection,
+{
+    let kind = Sys::get_disk_kind(disk);
+    let name = Sys::get_disk_name(disk).to_str();
     match name {
-        Some(name) => reclassify_virtual_hdd::<Fs>(kind, name) == DiskKind::HDD,
+        Some(name) => reclassify_virtual_hdd::<Sys>(kind, name) == DiskKind::HDD,
         None => kind == DiskKind::HDD, // can't parse name, keep original classification
     }
 }

--- a/src/app/hdd.rs
+++ b/src/app/hdd.rs
@@ -173,7 +173,10 @@ where
 /// this function should be revisited — virtual disks on macOS (e.g. virtio
 /// in QEMU) or FreeBSD (e.g. virtio-blk) could face the same misclassification.
 #[cfg(not(target_os = "linux"))]
-fn reclassify_virtual_hdd<Sys>(kind: DiskKind, _: &str) -> DiskKind {
+fn reclassify_virtual_hdd<Sys>(kind: DiskKind, _: &str) -> DiskKind
+where
+    Sys: Canonicalize,
+{
     kind
 }
 

--- a/src/app/hdd/test.rs
+++ b/src/app/hdd/test.rs
@@ -1,4 +1,7 @@
-use super::{DiskApi, FsApi, any_path_is_in_hdd, path_is_in_hdd};
+use super::{
+    Canonicalize, DiskSource, GetDiskKind, GetDiskName, GetMountPoint, any_path_is_in_hdd,
+    path_is_in_hdd,
+};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::ffi::OsStr;
@@ -6,14 +9,20 @@ use std::io;
 use std::path::{Path, PathBuf};
 use sysinfo::DiskKind;
 
-/// Fake disk for [`DiskApi`].
-struct Disk {
+#[cfg(target_os = "linux")]
+use super::{PathExists, ReadLink};
+
+/// Fake disk value read by the disk-reading capabilities.
+///
+/// It carries only the three fields the capabilities expose, standing in for
+/// [`sysinfo::Disk`], which a test cannot construct.
+struct FakeDisk {
     kind: DiskKind,
     name: &'static str,
     mount_point: &'static str,
 }
 
-impl Disk {
+impl FakeDisk {
     fn new(kind: DiskKind, name: &'static str, mount_point: &'static str) -> Self {
         Self {
             kind,
@@ -23,39 +32,52 @@ impl Disk {
     }
 }
 
-impl DiskApi for Disk {
-    fn get_disk_kind(&self) -> DiskKind {
-        self.kind
-    }
+/// Fake provider whose sysfs is empty.
+///
+/// `canonicalize` returns the path unchanged (all paths are canonical),
+/// `path_exists` returns `false`, and `read_link` returns `NotFound`, so
+/// [`reclassify_virtual_hdd`](super::reclassify_virtual_hdd) is effectively a
+/// no-op: disk kinds pass through unchanged. The provider holds no state, so it
+/// is shared across the tests in this module rather than declared inside each.
+struct EmptySysfs;
 
-    fn get_disk_name(&self) -> &OsStr {
-        OsStr::new(self.name)
-    }
+impl DiskSource for EmptySysfs {
+    type Disk = FakeDisk;
+}
 
-    fn get_mount_point(&self) -> &Path {
-        Path::new(self.mount_point)
+impl GetDiskKind for EmptySysfs {
+    fn get_disk_kind(disk: &Self::Disk) -> DiskKind {
+        disk.kind
     }
 }
 
-/// Mocked [`FsApi`] with no sysfs entries.
-///
-/// `canonicalize` returns the path unchanged (all paths are canonical).
-/// `path_exists` returns `false` and `read_link` returns `NotFound`,
-/// so [`reclassify_virtual_hdd`](super::reclassify_virtual_hdd) is
-/// effectively a no-op: disk kinds pass through unchanged.
-struct EmptyFs;
+impl GetDiskName for EmptySysfs {
+    fn get_disk_name(disk: &Self::Disk) -> &OsStr {
+        OsStr::new(disk.name)
+    }
+}
 
-impl FsApi for EmptyFs {
+impl GetMountPoint for EmptySysfs {
+    fn get_mount_point(disk: &Self::Disk) -> &Path {
+        Path::new(disk.mount_point)
+    }
+}
+
+impl Canonicalize for EmptySysfs {
     fn canonicalize(path: &Path) -> io::Result<PathBuf> {
         path.to_path_buf().pipe(Ok)
     }
+}
 
-    #[cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
+impl PathExists for EmptySysfs {
     fn path_exists(_: &Path) -> bool {
         false
     }
+}
 
-    #[cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
+impl ReadLink for EmptySysfs {
     fn read_link(_: &Path) -> io::Result<PathBuf> {
         Err(io::Error::new(io::ErrorKind::NotFound, "mocked"))
     }
@@ -64,11 +86,11 @@ impl FsApi for EmptyFs {
 #[test]
 fn test_any_path_in_hdd() {
     let disks = &[
-        Disk::new(DiskKind::SSD, "/dev/sda", "/"),
-        Disk::new(DiskKind::HDD, "/dev/sdb", "/home"),
-        Disk::new(DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
-        Disk::new(DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
-        Disk::new(DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
+        FakeDisk::new(DiskKind::SSD, "/dev/sda", "/"),
+        FakeDisk::new(DiskKind::HDD, "/dev/sdb", "/home"),
+        FakeDisk::new(DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
+        FakeDisk::new(DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
+        FakeDisk::new(DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
     ];
 
     let cases: &[(&[&str], bool)] = &[
@@ -96,18 +118,18 @@ fn test_any_path_in_hdd() {
     for (paths, in_hdd) in cases {
         let paths: Vec<_> = paths.iter().map(PathBuf::from).collect();
         println!("CASE: {paths:?} → {in_hdd:?}");
-        assert_eq!(any_path_is_in_hdd::<Disk, EmptyFs>(&paths, disks), *in_hdd);
+        assert_eq!(any_path_is_in_hdd::<EmptySysfs>(&paths, disks), *in_hdd);
     }
 }
 
 #[test]
 fn test_path_in_hdd() {
     let disks = &[
-        Disk::new(DiskKind::SSD, "/dev/sda", "/"),
-        Disk::new(DiskKind::HDD, "/dev/sdb", "/home"),
-        Disk::new(DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
-        Disk::new(DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
-        Disk::new(DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
+        FakeDisk::new(DiskKind::SSD, "/dev/sda", "/"),
+        FakeDisk::new(DiskKind::HDD, "/dev/sdb", "/home"),
+        FakeDisk::new(DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
+        FakeDisk::new(DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
+        FakeDisk::new(DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
     ];
 
     for (path, in_hdd) in [
@@ -118,9 +140,6 @@ fn test_path_in_hdd() {
         ("/mnt/ssd-data/test/test", false),
     ] {
         println!("CASE: {path} → {in_hdd:?}");
-        assert_eq!(
-            path_is_in_hdd::<Disk, EmptyFs>(Path::new(path), disks),
-            in_hdd,
-        );
+        assert_eq!(path_is_in_hdd::<EmptySysfs>(Path::new(path), disks), in_hdd);
     }
 }

--- a/src/app/hdd/test.rs
+++ b/src/app/hdd/test.rs
@@ -15,11 +15,6 @@ use super::{PathExists, ReadLink};
 /// Declare, inside the calling test, a function-scoped `DISKS` fixture and a
 /// zero-sized `FakeDisk` provider that reads it, so no state is shared between
 /// tests.
-///
-/// `FakeDisk` holds no state of its own: the disk records live in the `DISKS`
-/// static fixture, and each `Disk` value is one such record. The sysfs is
-/// empty, so `canonicalize` is the identity, `path_exists` is `false`, and
-/// `read_link` fails, which leaves every disk kind unchanged.
 macro_rules! empty_sysfs_fake {
     () => {
         static DISKS: &[(DiskKind, &str, &str)] = &[

--- a/src/app/hdd/test.rs
+++ b/src/app/hdd/test.rs
@@ -33,12 +33,6 @@ impl FakeDisk {
 }
 
 /// Fake provider whose sysfs is empty.
-///
-/// `canonicalize` returns the path unchanged (all paths are canonical),
-/// `path_exists` returns `false`, and `read_link` returns `NotFound`, so
-/// [`reclassify_virtual_hdd`](super::reclassify_virtual_hdd) is effectively a
-/// no-op: disk kinds pass through unchanged. The provider holds no state, so it
-/// is shared across the tests in this module rather than declared inside each.
 struct EmptySysfs;
 
 impl DiskSource for EmptySysfs {

--- a/src/app/hdd/test.rs
+++ b/src/app/hdd/test.rs
@@ -12,80 +12,73 @@ use sysinfo::DiskKind;
 #[cfg(target_os = "linux")]
 use super::{PathExists, ReadLink};
 
-/// Fake disk value read by the disk-reading capabilities.
+/// Declare, inside the calling test, a function-scoped `DISKS` fixture and a
+/// zero-sized `FakeDisk` provider that reads it, so no state is shared between
+/// tests.
 ///
-/// It carries only the three fields the capabilities expose, standing in for
-/// [`sysinfo::Disk`], which a test cannot construct.
-struct FakeDisk {
-    kind: DiskKind,
-    name: &'static str,
-    mount_point: &'static str,
-}
+/// `FakeDisk` holds no state of its own: the disk records live in the `DISKS`
+/// static fixture, and each `Disk` value is one such record. The sysfs is
+/// empty, so `canonicalize` is the identity, `path_exists` is `false`, and
+/// `read_link` fails, which leaves every disk kind unchanged.
+macro_rules! empty_sysfs_fake {
+    () => {
+        static DISKS: &[(DiskKind, &str, &str)] = &[
+            (DiskKind::SSD, "/dev/sda", "/"),
+            (DiskKind::HDD, "/dev/sdb", "/home"),
+            (DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
+            (DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
+            (DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
+        ];
 
-impl FakeDisk {
-    fn new(kind: DiskKind, name: &'static str, mount_point: &'static str) -> Self {
-        Self {
-            kind,
-            name,
-            mount_point,
+        struct FakeDisk;
+
+        impl DiskSource for FakeDisk {
+            type Disk = (DiskKind, &'static str, &'static str);
         }
-    }
-}
 
-/// Fake provider whose sysfs is empty.
-struct EmptySysfs;
+        impl GetDiskKind for FakeDisk {
+            fn get_disk_kind(disk: &Self::Disk) -> DiskKind {
+                disk.0
+            }
+        }
 
-impl DiskSource for EmptySysfs {
-    type Disk = FakeDisk;
-}
+        impl GetDiskName for FakeDisk {
+            fn get_disk_name(disk: &Self::Disk) -> &OsStr {
+                OsStr::new(disk.1)
+            }
+        }
 
-impl GetDiskKind for EmptySysfs {
-    fn get_disk_kind(disk: &Self::Disk) -> DiskKind {
-        disk.kind
-    }
-}
+        impl GetMountPoint for FakeDisk {
+            fn get_mount_point(disk: &Self::Disk) -> &Path {
+                Path::new(disk.2)
+            }
+        }
 
-impl GetDiskName for EmptySysfs {
-    fn get_disk_name(disk: &Self::Disk) -> &OsStr {
-        OsStr::new(disk.name)
-    }
-}
+        impl Canonicalize for FakeDisk {
+            fn canonicalize(path: &Path) -> io::Result<PathBuf> {
+                path.to_path_buf().pipe(Ok)
+            }
+        }
 
-impl GetMountPoint for EmptySysfs {
-    fn get_mount_point(disk: &Self::Disk) -> &Path {
-        Path::new(disk.mount_point)
-    }
-}
+        #[cfg(target_os = "linux")]
+        impl PathExists for FakeDisk {
+            fn path_exists(_: &Path) -> bool {
+                false
+            }
+        }
 
-impl Canonicalize for EmptySysfs {
-    fn canonicalize(path: &Path) -> io::Result<PathBuf> {
-        path.to_path_buf().pipe(Ok)
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl PathExists for EmptySysfs {
-    fn path_exists(_: &Path) -> bool {
-        false
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl ReadLink for EmptySysfs {
-    fn read_link(_: &Path) -> io::Result<PathBuf> {
-        Err(io::Error::new(io::ErrorKind::NotFound, "mocked"))
-    }
+        #[cfg(target_os = "linux")]
+        impl ReadLink for FakeDisk {
+            fn read_link(_: &Path) -> io::Result<PathBuf> {
+                Err(io::Error::new(io::ErrorKind::NotFound, "mocked"))
+            }
+        }
+    };
 }
 
 #[test]
 fn test_any_path_in_hdd() {
-    let disks = &[
-        FakeDisk::new(DiskKind::SSD, "/dev/sda", "/"),
-        FakeDisk::new(DiskKind::HDD, "/dev/sdb", "/home"),
-        FakeDisk::new(DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
-        FakeDisk::new(DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
-        FakeDisk::new(DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
-    ];
+    empty_sysfs_fake!();
 
     let cases: &[(&[&str], bool)] = &[
         (&[], false),
@@ -112,19 +105,13 @@ fn test_any_path_in_hdd() {
     for (paths, in_hdd) in cases {
         let paths: Vec<_> = paths.iter().map(PathBuf::from).collect();
         println!("CASE: {paths:?} → {in_hdd:?}");
-        assert_eq!(any_path_is_in_hdd::<EmptySysfs>(&paths, disks), *in_hdd);
+        assert_eq!(any_path_is_in_hdd::<FakeDisk>(&paths, DISKS), *in_hdd);
     }
 }
 
 #[test]
 fn test_path_in_hdd() {
-    let disks = &[
-        FakeDisk::new(DiskKind::SSD, "/dev/sda", "/"),
-        FakeDisk::new(DiskKind::HDD, "/dev/sdb", "/home"),
-        FakeDisk::new(DiskKind::HDD, "/dev/sdc", "/mnt/hdd-data"),
-        FakeDisk::new(DiskKind::SSD, "/dev/sdd", "/mnt/ssd-data"),
-        FakeDisk::new(DiskKind::HDD, "/dev/sde", "/mnt/hdd-data/repo"),
-    ];
+    empty_sysfs_fake!();
 
     for (path, in_hdd) in [
         ("/etc/fstab", false),
@@ -134,6 +121,6 @@ fn test_path_in_hdd() {
         ("/mnt/ssd-data/test/test", false),
     ] {
         println!("CASE: {path} → {in_hdd:?}");
-        assert_eq!(path_is_in_hdd::<EmptySysfs>(Path::new(path), disks), in_hdd);
+        assert_eq!(path_is_in_hdd::<FakeDisk>(Path::new(path), DISKS), in_hdd);
     }
 }

--- a/src/app/hdd/test_linux.rs
+++ b/src/app/hdd/test_linux.rs
@@ -1,4 +1,7 @@
-use super::{FsApi, VIRTUAL_DISK_KIND, parse_block_device_name, reclassify_virtual_hdd};
+use super::{
+    Canonicalize, PathExists, ReadLink, VIRTUAL_DISK_KIND, parse_block_device_name,
+    reclassify_virtual_hdd,
+};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::io;
@@ -39,7 +42,7 @@ fn test_parse_block_device_name() {
     }
 }
 
-/// Generate a test that builds a mock [`FsApi`] with identity `canonicalize`,
+/// Generate a test that builds a fake provider with identity `canonicalize`,
 /// then asserts that [`reclassify_virtual_hdd`] maps `DiskKind::HDD` to the
 /// expected `DiskKind`.
 ///
@@ -47,6 +50,10 @@ fn test_parse_block_device_name() {
 /// `/sys/block/{block}/device/driver`) are derived from `block_device`,
 /// so callers only supply the four varying pieces: block device name, kernel
 /// driver name, disk name, and expected `DiskKind`.
+///
+/// The provider's state, the `DEVICES` and `DRIVERS` tables, lives in `static`
+/// items declared inside each generated test function, so the tests share no
+/// storage and never race on it.
 macro_rules! identity_reclassify_test_case {
     (
         $(#[$attr:meta])*
@@ -64,13 +71,17 @@ macro_rules! identity_reclassify_test_case {
                 &[(concat!("/sys/block/", $block, "/device/driver"), $driver)];
 
             struct Fs;
-            impl FsApi for Fs {
+            impl Canonicalize for Fs {
                 fn canonicalize(path: &Path) -> io::Result<PathBuf> {
                     path.to_path_buf().pipe(Ok)
                 }
+            }
+            impl PathExists for Fs {
                 fn path_exists(path: &Path) -> bool {
                     DEVICES.iter().any(|dev| path == Path::new(*dev))
                 }
+            }
+            impl ReadLink for Fs {
                 fn read_link(path: &Path) -> io::Result<PathBuf> {
                     DRIVERS
                         .iter()
@@ -175,7 +186,7 @@ identity_reclassify_test_case! {
 #[test]
 fn test_mapper_symlink_resolves_to_virtual_partition() {
     struct Fs;
-    impl FsApi for Fs {
+    impl Canonicalize for Fs {
         fn canonicalize(path: &Path) -> io::Result<PathBuf> {
             [("/dev/mapper/vg0-lv0", "/dev/vda1")]
                 .iter()
@@ -183,9 +194,13 @@ fn test_mapper_symlink_resolves_to_virtual_partition() {
                 .map(|(_, target)| PathBuf::from(*target))
                 .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "mocked"))
         }
+    }
+    impl PathExists for Fs {
         fn path_exists(path: &Path) -> bool {
             ["/sys/block/vda"].iter().any(|dev| path == Path::new(*dev))
         }
+    }
+    impl ReadLink for Fs {
         fn read_link(path: &Path) -> io::Result<PathBuf> {
             [("/sys/block/vda/device/driver", "virtio_blk")]
                 .iter()
@@ -209,7 +224,7 @@ fn test_mapper_symlink_resolves_to_virtual_partition() {
 #[test]
 fn test_mapper_dm_device_is_not_corrected() {
     struct Fs;
-    impl FsApi for Fs {
+    impl Canonicalize for Fs {
         fn canonicalize(path: &Path) -> io::Result<PathBuf> {
             [("/dev/mapper/vg0-lv0", "/dev/dm-0")]
                 .iter()
@@ -217,16 +232,20 @@ fn test_mapper_dm_device_is_not_corrected() {
                 .map(|(_, target)| PathBuf::from(*target))
                 .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "mocked"))
         }
+    }
+    impl PathExists for Fs {
         fn path_exists(path: &Path) -> bool {
             path == Path::new("/sys/block/dm-0")
         }
+    }
+    impl ReadLink for Fs {
         fn read_link(_: &Path) -> io::Result<PathBuf> {
             Err(io::Error::new(io::ErrorKind::NotFound, "mocked"))
         }
     }
 
     // dm-0 is recognized but has no /sys/block/dm-0/device/driver
-    // symlink, so driver detection fails — HDD classification is preserved.
+    // symlink, so driver detection fails and HDD classification is preserved.
     assert_eq!(
         reclassify_virtual_hdd::<Fs>(DiskKind::HDD, "/dev/mapper/vg0-lv0"),
         DiskKind::HDD,
@@ -237,13 +256,17 @@ fn test_mapper_dm_device_is_not_corrected() {
 #[test]
 fn test_ssd_is_not_corrected() {
     struct Fs;
-    impl FsApi for Fs {
+    impl Canonicalize for Fs {
         fn canonicalize(_: &Path) -> io::Result<PathBuf> {
             panic!("canonicalize should not be called for non-HDD disks");
         }
+    }
+    impl PathExists for Fs {
         fn path_exists(_: &Path) -> bool {
             panic!("path_exists should not be called for non-HDD disks");
         }
+    }
+    impl ReadLink for Fs {
         fn read_link(_: &Path) -> io::Result<PathBuf> {
             panic!("read_link should not be called for non-HDD disks");
         }

--- a/src/app/hdd/test_linux.rs
+++ b/src/app/hdd/test_linux.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use sysinfo::DiskKind;
 
-/// Test pure parsing of block device names — no sysfs dependency.
+/// Test the pure parsing of block device names, which has no sysfs dependency.
 #[test]
 fn test_parse_block_device_name() {
     let cases: &[(&str, Option<&str>)] = &[
@@ -252,7 +252,7 @@ fn test_mapper_dm_device_is_not_corrected() {
     );
 }
 
-/// SSD disk should pass through unchanged — correction is not applied.
+/// An SSD disk should pass through unchanged, because correction is not applied.
 #[test]
 fn test_ssd_is_not_corrected() {
     struct Fs;

--- a/src/app/hdd/test_linux_smoke.rs
+++ b/src/app/hdd/test_linux_smoke.rs
@@ -1,11 +1,12 @@
-use super::{RealFs, extract_block_device_name, is_virtual_block_device};
+use super::{extract_block_device_name, is_virtual_block_device};
+use crate::app::host::Host;
 
 /// On hosts with a `/sys/block/vda` device, exercises the detection
 /// pipeline without panicking. Silently skips if `vda` does not exist.
 #[test]
 fn real_sysfs_vda_does_not_panic() {
     if std::path::Path::new("/sys/block/vda").exists() {
-        let _ = is_virtual_block_device::<RealFs>("vda");
+        let _ = is_virtual_block_device::<Host>("vda");
     }
 }
 
@@ -13,7 +14,7 @@ fn real_sysfs_vda_does_not_panic() {
 #[test]
 fn nonexistent_device_is_not_virtual() {
     assert!(
-        !is_virtual_block_device::<RealFs>("nonexistent_device_xyz"),
+        !is_virtual_block_device::<Host>("nonexistent_device_xyz"),
         "non-existent device should not be detected as virtual",
     );
 }
@@ -29,8 +30,8 @@ fn full_pipeline_does_not_panic() {
     let disks = Disks::new_with_refreshed_list();
     for disk in disks.list() {
         let name = disk.name().to_str().unwrap_or_default();
-        if let Some(block_dev) = extract_block_device_name::<RealFs>(name) {
-            let _ = is_virtual_block_device::<RealFs>(&block_dev);
+        if let Some(block_dev) = extract_block_device_name::<Host>(name) {
+            let _ = is_virtual_block_device::<Host>(&block_dev);
         }
     }
 }

--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -1,14 +1,2 @@
 /// The production provider for the crate's dependency-injection seams.
-///
-/// It implements every capability trait defined for testing (see the
-/// "Dependency Injection for Tests" section of `CONTRIBUTING.md`) by
-/// delegating to the real operating system. Production call sites name it
-/// explicitly through a turbofish, such as `any_path_is_in_hdd::<Host>(…)`,
-/// so the production choice of provider is visible at the call site.
-///
-/// The capability traits themselves, together with their implementations for
-/// this provider, live next to the logic that consumes them: the disk and
-/// filesystem capabilities in [`hdd`](super::hdd), and the argument
-/// resolution capabilities in
-/// [`overlapping_arguments`](super::overlapping_arguments).
 pub struct Host;

--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -1,0 +1,14 @@
+/// The production provider for the crate's dependency-injection seams.
+///
+/// It implements every capability trait defined for testing (see the
+/// "Dependency Injection for Tests" section of `CONTRIBUTING.md`) by
+/// delegating to the real operating system. Production call sites name it
+/// explicitly through a turbofish, such as `any_path_is_in_hdd::<Host>(…)`,
+/// so the production choice of provider is visible at the call site.
+///
+/// The capability traits themselves, together with their implementations for
+/// this provider, live next to the logic that consumes them: the disk and
+/// filesystem capabilities in [`hdd`](super::hdd), and the argument
+/// resolution capabilities in
+/// [`overlapping_arguments`](super::overlapping_arguments).
+pub struct Host;

--- a/src/app/overlapping_arguments.rs
+++ b/src/app/overlapping_arguments.rs
@@ -6,10 +6,6 @@ use std::mem::take;
 use std::path::PathBuf;
 
 /// The command-line argument that the argument-resolution capabilities operate on.
-///
-/// The argument type is exposed as an associated type so that production can
-/// resolve real [`PathBuf`] arguments while a test substitutes a lightweight
-/// stand-in, such as a `&'static str`, that its fake filesystem understands.
 pub trait ArgumentSource {
     /// The argument value that the capabilities below resolve.
     type Argument;

--- a/src/app/overlapping_arguments.rs
+++ b/src/app/overlapping_arguments.rs
@@ -1,49 +1,65 @@
+use super::host::Host;
 use pipe_trait::Pipe;
 use std::collections::HashSet;
 use std::fs::{canonicalize, symlink_metadata};
-use std::io;
 use std::mem::take;
 use std::path::PathBuf;
 
-/// Mockable APIs to interact with the system.
-pub trait Api {
+/// The command-line argument that the argument-resolution capabilities operate on.
+///
+/// The argument type is exposed as an associated type so that production can
+/// resolve real [`PathBuf`] arguments while a test substitutes a lightweight
+/// stand-in, such as a `&'static str`, that its fake filesystem understands.
+pub trait ArgumentSource {
+    /// The argument value that the capabilities below resolve.
     type Argument;
-    type RealPath: Eq;
-    type RealPathError;
-    fn canonicalize(path: &Self::Argument) -> Result<Self::RealPath, Self::RealPathError>;
-    fn is_real_dir(path: &Self::Argument) -> bool;
-    fn starts_with(path: &Self::RealPath, prefix: &Self::RealPath) -> bool;
 }
 
-/// Implementation of [`Api`] that interacts with the real system.
-pub struct RealApi;
-impl Api for RealApi {
+/// Capability: resolve an argument to its canonical real path.
+///
+/// Returns `None` when the argument cannot be resolved, for example because it
+/// does not exist. This mirrors [`std::fs::canonicalize`] followed by
+/// discarding the error, which is all the caller needs.
+pub trait CanonicalizeArgument: ArgumentSource {
+    fn canonicalize(argument: &Self::Argument) -> Option<PathBuf>;
+}
+
+/// Capability: check whether an argument refers to a real directory.
+///
+/// A symbolic link, even one pointing at a directory, is not a real directory
+/// for this purpose, mirroring the check on [`std::fs::symlink_metadata`].
+pub trait IsRealDir: ArgumentSource {
+    fn is_real_dir(argument: &Self::Argument) -> bool;
+}
+
+impl ArgumentSource for Host {
     type Argument = PathBuf;
-    type RealPath = PathBuf;
-    type RealPathError = io::Error;
+}
 
+impl CanonicalizeArgument for Host {
     #[inline]
-    fn canonicalize(path: &Self::Argument) -> Result<Self::RealPath, Self::RealPathError> {
-        canonicalize(path)
+    fn canonicalize(argument: &Self::Argument) -> Option<PathBuf> {
+        canonicalize(argument).ok()
     }
+}
 
+impl IsRealDir for Host {
     #[inline]
-    fn is_real_dir(path: &Self::Argument) -> bool {
-        path.pipe(symlink_metadata)
+    fn is_real_dir(argument: &Self::Argument) -> bool {
+        argument
+            .pipe(symlink_metadata)
             .is_ok_and(|metadata| !metadata.is_symlink() && metadata.is_dir())
-    }
-
-    #[inline]
-    fn starts_with(path: &Self::RealPath, prefix: &Self::RealPath) -> bool {
-        path.starts_with(prefix)
     }
 }
 
 /// Hardlinks deduplication doesn't work properly if there are more than 1 paths pointing to
 /// the same tree or if a path points to a subtree of another path. Therefore, we must find
 /// and remove such overlapping paths before they cause problems.
-pub fn remove_overlapping_paths<Api: self::Api>(arguments: &mut Vec<Api::Argument>) {
-    let to_remove = find_overlapping_paths_to_remove::<Api>(arguments);
+pub fn remove_overlapping_paths<Sys>(arguments: &mut Vec<Sys::Argument>)
+where
+    Sys: CanonicalizeArgument + IsRealDir,
+{
+    let to_remove = find_overlapping_paths_to_remove::<Sys>(arguments);
     remove_items_from_vec_by_indices(arguments, &to_remove);
 }
 
@@ -53,15 +69,16 @@ pub fn remove_overlapping_paths<Api: self::Api>(arguments: &mut Vec<Api::Argumen
 ///
 /// Prefer keeping the first instance of the path over the later instances (returning the indices of
 /// the later instances).
-pub fn find_overlapping_paths_to_remove<Api: self::Api>(
-    arguments: &[Api::Argument],
-) -> HashSet<usize> {
+pub fn find_overlapping_paths_to_remove<Sys>(arguments: &[Sys::Argument]) -> HashSet<usize>
+where
+    Sys: CanonicalizeArgument + IsRealDir,
+{
     let real_paths: Vec<_> = arguments
         .iter()
         .map(|path| {
-            Api::is_real_dir(path)
-                .then(|| Api::canonicalize(path))
-                .and_then(Result::ok)
+            Sys::is_real_dir(path)
+                .then(|| Sys::canonicalize(path))
+                .flatten()
         })
         .collect();
     assert_eq!(arguments.len(), real_paths.len());
@@ -77,13 +94,13 @@ pub fn find_overlapping_paths_to_remove<Api: self::Api>(
                 }
 
                 // `left` starts with `right` means `left` is subtree of `right`, remove `left`
-                if Api::starts_with(left, right) {
+                if left.starts_with(right) {
                     to_remove.insert(left_index);
                     continue;
                 }
 
                 // `right` starts with `left` means `right` is subtree of `left`, remove `right`
-                if Api::starts_with(right, left) {
+                if right.starts_with(left) {
                     to_remove.insert(right_index);
                     continue;
                 }

--- a/src/app/overlapping_arguments/test_remove_overlapping_paths.rs
+++ b/src/app/overlapping_arguments/test_remove_overlapping_paths.rs
@@ -1,8 +1,7 @@
-use super::{Api, remove_overlapping_paths};
+use super::{ArgumentSource, CanonicalizeArgument, IsRealDir, remove_overlapping_paths};
 use normalize_path::NormalizePath;
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
-use std::convert::Infallible;
 use std::path::PathBuf;
 
 const MOCKED_CURRENT_DIR: &str = "/home/user/current-dir";
@@ -42,31 +41,34 @@ fn resolve_symlink(absolute_path: PathBuf) -> PathBuf {
     absolute_path
 }
 
-/// Mocked implementation of [`Api`] for testing purposes.
-struct MockedApi;
-impl Api for MockedApi {
-    type Argument = &'static str;
-    type RealPath = PathBuf;
-    type RealPathError = Infallible;
+/// Fake filesystem whose symlinks and current directory are the module
+/// constants above.
+///
+/// The provider holds no state of its own, so it is shared across the tests in
+/// this module rather than declared inside each.
+struct SymlinkFs;
 
-    fn canonicalize(path: &Self::Argument) -> Result<Self::RealPath, Self::RealPathError> {
+impl ArgumentSource for SymlinkFs {
+    type Argument = &'static str;
+}
+
+impl CanonicalizeArgument for SymlinkFs {
+    fn canonicalize(argument: &Self::Argument) -> Option<PathBuf> {
         MOCKED_CURRENT_DIR
             .pipe(PathBuf::from)
-            .join(path)
+            .join(argument)
             .normalize()
             .pipe(resolve_symlink)
-            .pipe(Ok)
+            .pipe(Some)
     }
+}
 
-    fn is_real_dir(path: &Self::Argument) -> bool {
-        let path = MOCKED_CURRENT_DIR.pipe(PathBuf::from).join(path);
+impl IsRealDir for SymlinkFs {
+    fn is_real_dir(argument: &Self::Argument) -> bool {
+        let path = MOCKED_CURRENT_DIR.pipe(PathBuf::from).join(argument);
         MOCKED_SYMLINKS
             .iter()
             .all(|(link, _)| PathBuf::from(link).normalize() != path)
-    }
-
-    fn starts_with(path: &Self::RealPath, prefix: &Self::RealPath) -> bool {
-        path.starts_with(prefix)
     }
 }
 
@@ -75,7 +77,7 @@ impl Api for MockedApi {
 fn remove_nothing() {
     let original = vec!["foo", "bar", "abc/def", "0/1/2"];
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = original;
     assert_eq!(actual, expected);
 }
@@ -93,7 +95,7 @@ fn remove_duplicated_arguments() {
         "./abc/./def",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["foo", "bar", "abc/def", "0/1/2"];
     assert_eq!(actual, expected);
 
@@ -107,7 +109,7 @@ fn remove_duplicated_arguments() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["foo", "./bar", "./abc/./def", "0/1/2"];
     assert_eq!(actual, expected);
 }
@@ -125,7 +127,7 @@ fn remove_overlapping_sub_paths() {
         "0/1/2/3",
     ];
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["foo", "bar", "abc/def", "0/1/2"];
     assert_eq!(actual, expected);
 }
@@ -135,7 +137,7 @@ fn remove_overlapping_sub_paths() {
 fn remove_all_except_current_dir() {
     let original = dbg!(vec!["foo", "bar", ".", "abc/def", "0/1/2"]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["."];
     assert_eq!(actual, expected);
 
@@ -148,7 +150,7 @@ fn remove_all_except_current_dir() {
         MOCKED_CURRENT_DIR,
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["."];
     assert_eq!(actual, expected);
 
@@ -161,7 +163,7 @@ fn remove_all_except_current_dir() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec![MOCKED_CURRENT_DIR];
     assert_eq!(actual, expected);
 }
@@ -171,7 +173,7 @@ fn remove_all_except_current_dir() {
 fn remove_all_except_parent_dir() {
     let original = dbg!(vec!["foo", "bar", "..", "abc/def", ".", "0/1/2"]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec![".."];
     assert_eq!(actual, expected);
 
@@ -185,7 +187,7 @@ fn remove_all_except_parent_dir() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["/home/user"];
     assert_eq!(actual, expected);
 }
@@ -202,7 +204,7 @@ fn remove_overlapping_real_paths() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["foo", "bar", "abc/def", "0/1/2"];
     assert_eq!(actual, expected);
 
@@ -215,7 +217,7 @@ fn remove_overlapping_real_paths() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["foo", "bar", "abc/def", "0/1/2"];
     assert_eq!(actual, expected);
 
@@ -228,7 +230,7 @@ fn remove_overlapping_real_paths() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = vec!["link-to-current-dir/foo", "bar", "abc/def", "0/1/2"];
     assert_eq!(actual, expected);
 }
@@ -245,7 +247,7 @@ fn do_not_remove_symlinks() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = original;
     assert_eq!(actual, expected);
 
@@ -258,7 +260,7 @@ fn do_not_remove_symlinks() {
         "0/1/2",
     ]);
     let mut actual = original.clone();
-    remove_overlapping_paths::<MockedApi>(&mut actual);
+    remove_overlapping_paths::<SymlinkFs>(&mut actual);
     let expected = original;
     assert_eq!(actual, expected);
 }

--- a/src/app/overlapping_arguments/test_remove_overlapping_paths.rs
+++ b/src/app/overlapping_arguments/test_remove_overlapping_paths.rs
@@ -43,9 +43,6 @@ fn resolve_symlink(absolute_path: PathBuf) -> PathBuf {
 
 /// Fake filesystem whose symlinks and current directory are the module
 /// constants above.
-///
-/// The provider holds no state of its own, so it is shared across the tests in
-/// this module rather than declared inside each.
 struct SymlinkFs;
 
 impl ArgumentSource for SymlinkFs {


### PR DESCRIPTION
Adopts the dependency-injection-for-tests pattern from pnpm's Rust code across parallel-disk-usage. The three previous DI traits, `DiskApi`, `FsApi`, and `overlapping_arguments::Api`, are replaced with single-method capability traits whose methods are `self`-less associated functions bound to one generic `Sys`.

`DiskApi` becomes `GetDiskKind`, `GetDiskName`, and `GetMountPoint` over a `DiskSource` associated disk type, so production reads a real `sysinfo::Disk` while a test substitutes a lightweight stand-in. `FsApi` becomes `Canonicalize`, `PathExists`, and `ReadLink`. `overlapping_arguments::Api` becomes `CanonicalizeArgument` and `IsRealDir` over an `ArgumentSource` associated argument type, and its pure `starts_with`, which touches no side effect, is demoted from a capability to an ordinary method call. A single crate-wide `Host` provider in `src/app/host.rs` supplies the real implementations, and production call sites name it through an explicit turbofish.

Each test declares its own zero-sized fake provider and keeps any fixture state in function-scoped `static` items rather than module-level or global ones, so nothing is shared between tests. The sole exception is the stateless `SymlinkFs`, which has nothing to race on and so is shared at module scope. The pattern is documented in a new "Dependency Injection for Tests" section of `CONTRIBUTING.md`.